### PR TITLE
Enhance free plan upsell and restrict dashboard access for free plan

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8709,9 +8709,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -16591,9 +16591,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -137,6 +137,8 @@
     "react-router": "6.30.2",
     "serialize-javascript": "7.0.5",
     "svgo": "3.3.3",
-    "follow-redirects": "1.16.0"
+    "follow-redirects": "1.16.0",
+    "dompurify": "^3.4.0",
+    "protobufjs": "^7.5.5"
   }
 }

--- a/ui/src/components/Dashboard/Dashboard.tsx
+++ b/ui/src/components/Dashboard/Dashboard.tsx
@@ -23,6 +23,7 @@ import { handleUserLoginNotification } from '../../utils/userNotifications';
 import { getApiUrl } from '../../utils/apiUrl';
 import { useAppSelector } from '../../store/configureStore';
 import { isCloudMode } from '../../utils/deploymentMode';
+import { useOrgContext } from '../../hooks/useOrgContext';
 import apiClient from '../../api/apiClient';
 
 type DashboardBillingStatusResponse = {
@@ -119,6 +120,7 @@ const saveDismissedConnectorIds = (storageKey: string, connectorIds: Set<number>
 export const Dashboard: React.FC = () => {
     const navigate = useNavigate();
     const user = useAppSelector(state => state.Auth.user);
+    const { isFreePlan } = useOrgContext();
 
     // Dashboard data state
     const [dashboardData, setDashboardData] = useState<DashboardData | null>(null);
@@ -449,10 +451,16 @@ export const Dashboard: React.FC = () => {
                             variant="primary"
                             icon={<Icons.Add />}
                             onClick={() => navigate('/reviews/new')}
-                            className="shadow-xl hover:shadow-2xl transition-all duration-300 hover:scale-105 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600"
-                            title="Safe review - no comments posted"
+                            disabled={isFreePlan}
+                            className={classNames(
+                                "shadow-xl transition-all duration-300",
+                                isFreePlan 
+                                    ? "opacity-60 grayscale cursor-not-allowed" 
+                                    : "hover:shadow-2xl hover:scale-105 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600"
+                            )}
+                            title={isFreePlan ? "Upgrade your plan to create reviews" : "Safe review - no comments posted"}
                         >
-                            New Review
+                            {isFreePlan ? "Create Review (Locked)" : "New Review"}
                         </Button>
                     </div>
                 </div>
@@ -532,9 +540,15 @@ export const Dashboard: React.FC = () => {
                     variant="primary"
                     icon={<Icons.Add />}
                     onClick={() => navigate('/reviews/new')}
-                    className="fixed bottom-6 right-6 sm:hidden z-40 rounded-full w-14 h-14 shadow-xl hover:shadow-2xl transition-all duration-300 hover:scale-110 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600"
-                    aria-label="New Review (Safe - no comments posted)"
-                    title="Safe review - no comments posted"
+                    disabled={isFreePlan}
+                    className={classNames(
+                        "fixed bottom-6 right-6 sm:hidden z-40 rounded-full w-14 h-14 shadow-xl transition-all duration-300",
+                        isFreePlan 
+                            ? "opacity-60 grayscale cursor-not-allowed bg-slate-700" 
+                            : "hover:shadow-2xl hover:scale-110 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600"
+                    )}
+                    aria-label={isFreePlan ? "Review creation locked" : "New Review (Safe - no comments posted)"}
+                    title={isFreePlan ? "Upgrade your plan to create reviews" : "Safe review - no comments posted"}
                 />
 
                 {/* Get Started stepper – stays visible until the user manually dismisses it */}
@@ -548,6 +562,7 @@ export const Dashboard: React.FC = () => {
                         onConfigureAI={() => navigate('/ai')}
                         onNewReview={() => navigate('/reviews/new')}
                         userId={user?.id}
+                        isFreePlan={isFreePlan}
                         onDismiss={() => {
                             setHideStepper(true);
                             try {

--- a/ui/src/components/Dashboard/Dashboard.tsx
+++ b/ui/src/components/Dashboard/Dashboard.tsx
@@ -24,6 +24,7 @@ import { getApiUrl } from '../../utils/apiUrl';
 import { useAppSelector } from '../../store/configureStore';
 import { isCloudMode } from '../../utils/deploymentMode';
 import { useOrgContext } from '../../hooks/useOrgContext';
+import LicenseUpgradeDialog from '../License/LicenseUpgradeDialog';
 import apiClient from '../../api/apiClient';
 
 type DashboardBillingStatusResponse = {
@@ -139,6 +140,7 @@ export const Dashboard: React.FC = () => {
     const [notificationSent, setNotificationSent] = useState(false);
     // Track dismissed connector progress notifications for this tab session
     const [dismissedConnectors, setDismissedConnectors] = useState<Set<number>>(new Set());
+    const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
     // Track connector warnings explicitly hidden by the user across page reloads
     const [persistedDismissedConnectors, setPersistedDismissedConnectors] = useState<Set<number>>(new Set());
     const [billingInsight, setBillingInsight] = useState<DashboardBillingInsight | null>(null);
@@ -450,17 +452,17 @@ export const Dashboard: React.FC = () => {
                         <Button
                             variant="primary"
                             icon={<Icons.Add />}
-                            onClick={() => navigate('/reviews/new')}
-                            disabled={isFreePlan}
-                            className={classNames(
-                                "shadow-xl transition-all duration-300",
-                                isFreePlan 
-                                    ? "opacity-60 grayscale cursor-not-allowed" 
-                                    : "hover:shadow-2xl hover:scale-105 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600"
-                            )}
+                            onClick={() => {
+                                if (isFreePlan) {
+                                    setShowUpgradeDialog(true);
+                                } else {
+                                    navigate('/reviews/new');
+                                }
+                            }}
+                            className="shadow-xl transition-all duration-300 hover:shadow-2xl hover:scale-105 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600"
                             title={isFreePlan ? "Upgrade your plan to create reviews" : "Safe review - no comments posted"}
                         >
-                            {isFreePlan ? "Create Review (Locked)" : "New Review"}
+                            New Review
                         </Button>
                     </div>
                 </div>
@@ -539,14 +541,14 @@ export const Dashboard: React.FC = () => {
                 <Button
                     variant="primary"
                     icon={<Icons.Add />}
-                    onClick={() => navigate('/reviews/new')}
-                    disabled={isFreePlan}
-                    className={classNames(
-                        "fixed bottom-6 right-6 sm:hidden z-40 rounded-full w-14 h-14 shadow-xl transition-all duration-300",
-                        isFreePlan 
-                            ? "opacity-60 grayscale cursor-not-allowed bg-slate-700" 
-                            : "hover:shadow-2xl hover:scale-110 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600"
-                    )}
+                    onClick={() => {
+                        if (isFreePlan) {
+                            setShowUpgradeDialog(true);
+                        } else {
+                            navigate('/reviews/new');
+                        }
+                    }}
+                    className="fixed bottom-6 right-6 sm:hidden z-40 rounded-full w-14 h-14 shadow-xl transition-all duration-300 hover:shadow-2xl hover:scale-110 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600"
                     aria-label={isFreePlan ? "Review creation locked" : "New Review (Safe - no comments posted)"}
                     title={isFreePlan ? "Upgrade your plan to create reviews" : "Safe review - no comments posted"}
                 />
@@ -563,6 +565,7 @@ export const Dashboard: React.FC = () => {
                         onNewReview={() => navigate('/reviews/new')}
                         userId={user?.id}
                         isFreePlan={isFreePlan}
+                        onUpgrade={() => setShowUpgradeDialog(true)}
                         onDismiss={() => {
                             setHideStepper(true);
                             try {
@@ -707,6 +710,15 @@ export const Dashboard: React.FC = () => {
                         )}
                     </div>
                 </div>
+
+                {/* Upgrade Modal */}
+                <LicenseUpgradeDialog
+                    open={showUpgradeDialog}
+                    onClose={() => setShowUpgradeDialog(false)}
+                    requiredTier="team"
+                    featureName="Review Creation From Dashboard"
+                    featureDescription="Unlock AI-powered code reviews by upgrading to a paid plan. Your current plan is read-only."
+                />
             </main>
         </div>
     );

--- a/ui/src/components/Dashboard/Dashboard.tsx
+++ b/ui/src/components/Dashboard/Dashboard.tsx
@@ -336,6 +336,14 @@ export const Dashboard: React.FC = () => {
         }
     };
 
+    const handleNewReviewClick = () => {
+        if (isFreePlan) {
+            setShowUpgradeDialog(true);
+        } else {
+            navigate('/reviews/new');
+        }
+    };
+
     return (
         <div className="min-h-screen">
             <main className="container mx-auto px-4 py-6">
@@ -452,13 +460,7 @@ export const Dashboard: React.FC = () => {
                         <Button
                             variant="primary"
                             icon={<Icons.Add />}
-                            onClick={() => {
-                                if (isFreePlan) {
-                                    setShowUpgradeDialog(true);
-                                } else {
-                                    navigate('/reviews/new');
-                                }
-                            }}
+                            onClick={handleNewReviewClick}
                             className="shadow-xl transition-all duration-300 hover:shadow-2xl hover:scale-105 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600"
                             title={isFreePlan ? "Upgrade your plan to create reviews" : "Safe review - no comments posted"}
                         >
@@ -541,13 +543,7 @@ export const Dashboard: React.FC = () => {
                 <Button
                     variant="primary"
                     icon={<Icons.Add />}
-                    onClick={() => {
-                        if (isFreePlan) {
-                            setShowUpgradeDialog(true);
-                        } else {
-                            navigate('/reviews/new');
-                        }
-                    }}
+                    onClick={handleNewReviewClick}
                     className="fixed bottom-6 right-6 sm:hidden z-40 rounded-full w-14 h-14 shadow-xl transition-all duration-300 hover:shadow-2xl hover:scale-110 bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-500 hover:to-blue-600"
                     aria-label={isFreePlan ? "Review creation locked" : "New Review (Safe - no comments posted)"}
                     title={isFreePlan ? "Upgrade your plan to create reviews" : "Safe review - no comments posted"}

--- a/ui/src/components/Dashboard/OnboardingStepper.tsx
+++ b/ui/src/components/Dashboard/OnboardingStepper.tsx
@@ -15,6 +15,7 @@ interface OnboardingStepperProps {
   className?: string;
   userId?: number | string; // For scoping localStorage to user
   isFreePlan?: boolean;
+  onUpgrade?: () => void;
 }
 
 const Step: React.FC<{
@@ -83,6 +84,7 @@ export const OnboardingStepper: React.FC<OnboardingStepperProps> = ({
   className,
   userId,
   isFreePlan = false,
+  onUpgrade,
 }) => {
   const allSet = hasCLI && hasAIProvider;
   const [collapsed, setCollapsed] = useState<boolean>(() => {
@@ -120,11 +122,16 @@ export const OnboardingStepper: React.FC<OnboardingStepperProps> = ({
                 variant="primary" 
                 size="sm" 
                 icon={<Icons.Add />} 
-                onClick={onNewReview}
-                disabled={isFreePlan}
+                onClick={() => {
+                  if (isFreePlan && onUpgrade) {
+                    onUpgrade();
+                  } else {
+                    onNewReview();
+                  }
+                }}
                 title={isFreePlan ? "Upgrade your plan to create reviews" : undefined}
             >
-              {isFreePlan ? "Create Review (Locked)" : "New Review"}
+              New Review
             </Button>
           )}
           <Button
@@ -171,11 +178,16 @@ export const OnboardingStepper: React.FC<OnboardingStepperProps> = ({
                 size="sm" 
                 variant="outline" 
                 icon={<Icons.AI />} 
-                onClick={onConfigureAI}
-                disabled={isFreePlan}
+                onClick={() => {
+                  if (isFreePlan && onUpgrade) {
+                    onUpgrade();
+                  } else {
+                    onConfigureAI();
+                  }
+                }}
                 title={isFreePlan ? "Upgrade your plan to configure AI" : undefined}
               >
-                {isFreePlan ? "Configure (Locked)" : "Configure"}
+                Configure
               </Button>
             )
           }

--- a/ui/src/components/Dashboard/OnboardingStepper.tsx
+++ b/ui/src/components/Dashboard/OnboardingStepper.tsx
@@ -14,6 +14,7 @@ interface OnboardingStepperProps {
   onDismiss?: () => void;
   className?: string;
   userId?: number | string; // For scoping localStorage to user
+  isFreePlan?: boolean;
 }
 
 const Step: React.FC<{
@@ -81,6 +82,7 @@ export const OnboardingStepper: React.FC<OnboardingStepperProps> = ({
   onDismiss,
   className,
   userId,
+  isFreePlan = false,
 }) => {
   const allSet = hasCLI && hasAIProvider;
   const [collapsed, setCollapsed] = useState<boolean>(() => {
@@ -114,8 +116,15 @@ export const OnboardingStepper: React.FC<OnboardingStepperProps> = ({
         </div>
         <div className="flex items-center gap-2 sm:gap-3 flex-wrap justify-start lg:justify-end">
           {allSet && collapsed && (
-            <Button variant="primary" size="sm" icon={<Icons.Add />} onClick={onNewReview}>
-              New Review
+            <Button 
+                variant="primary" 
+                size="sm" 
+                icon={<Icons.Add />} 
+                onClick={onNewReview}
+                disabled={isFreePlan}
+                title={isFreePlan ? "Upgrade your plan to create reviews" : undefined}
+            >
+              {isFreePlan ? "Create Review (Locked)" : "New Review"}
             </Button>
           )}
           <Button
@@ -158,8 +167,15 @@ export const OnboardingStepper: React.FC<OnboardingStepperProps> = ({
           done={hasAIProvider}
           action={
             !hasAIProvider && (
-              <Button size="sm" variant="outline" icon={<Icons.AI />} onClick={onConfigureAI}>
-                Configure
+              <Button 
+                size="sm" 
+                variant="outline" 
+                icon={<Icons.AI />} 
+                onClick={onConfigureAI}
+                disabled={isFreePlan}
+                title={isFreePlan ? "Upgrade your plan to configure AI" : undefined}
+              >
+                {isFreePlan ? "Configure (Locked)" : "Configure"}
               </Button>
             )
           }

--- a/ui/src/components/License/LicenseUpgradeDialog.tsx
+++ b/ui/src/components/License/LicenseUpgradeDialog.tsx
@@ -17,25 +17,41 @@ interface LicenseUpgradeDialogProps {
 
 interface FeatureRow {
   feature: string;
-  community: boolean;
-  team: boolean;
+  individual: boolean;
+  premium: boolean;
   enterprise: boolean;
 }
 
 const FEATURE_COMPARISON: FeatureRow[] = [
-  { feature: 'Basic Code Reviews', community: true, team: true, enterprise: true },
-  { feature: 'Git Provider Integration', community: true, team: true, enterprise: true },
-  { feature: 'AI Provider Configuration', community: true, team: true, enterprise: true },
-  { feature: 'Dashboard & Analytics', community: true, team: true, enterprise: true },
-  { feature: 'Prompt Customization', community: false, team: true, enterprise: true },
-  { feature: 'Learnings Management', community: false, team: true, enterprise: true },
-  { feature: 'Multiple API Keys', community: false, team: true, enterprise: true },
-  { feature: 'Team Management (>3 users)', community: false, team: true, enterprise: true },
-  { feature: 'Priority Support', community: false, team: true, enterprise: true },
-  { feature: 'SSO / SAML', community: false, team: false, enterprise: true },
-  { feature: 'Audit Logs', community: false, team: false, enterprise: true },
-  { feature: 'Compliance Reports', community: false, team: false, enterprise: true },
-  { feature: 'Custom Integrations', community: false, team: false, enterprise: true },
+  // Productivity
+  { feature: 'Unlimited reviews', individual: true, premium: true, enterprise: true },
+  { feature: 'Unlimited projects', individual: true, premium: true, enterprise: true },
+  { feature: 'Unlimited team members', individual: false, premium: true, enterprise: true },
+  { feature: 'Discuss/Debate with AI', individual: false, premium: true, enterprise: true },
+  { feature: 'Engineering Insights', individual: false, premium: true, enterprise: true },
+
+  // AI & Models
+  { feature: 'Bring your own AI Keys', individual: true, premium: true, enterprise: true },
+  { feature: 'Cloud AI Models', individual: false, premium: true, enterprise: true },
+  { feature: 'Local AI (Ollama)', individual: false, premium: false, enterprise: true },
+  { feature: 'Self-hosted AI', individual: false, premium: false, enterprise: true },
+
+  // Integrations
+  { feature: 'Participate in PR Threads', individual: false, premium: true, enterprise: true },
+  { feature: 'Full API Access', individual: false, premium: true, enterprise: true },
+  { feature: 'Git-Native CLI (git-lrc)', individual: true, premium: true, enterprise: true },
+  { feature: 'VS Code Extension', individual: true, premium: true, enterprise: true },
+
+  // Security & Ops
+  { feature: 'Support for multiple organizations', individual: false, premium: false, enterprise: true },
+  { feature: 'SSO & Directory Sync', individual: false, premium: false, enterprise: true },
+  { feature: 'Self-hosted Option', individual: false, premium: false, enterprise: true },
+  { feature: 'Custom Domain', individual: false, premium: false, enterprise: true },
+  { feature: 'Full Data Privacy', individual: false, premium: false, enterprise: true },
+
+  // Support
+  { feature: 'Priority Support', individual: false, premium: true, enterprise: true },
+  { feature: 'Dedicated SLA', individual: false, premium: false, enterprise: true },
 ];
 
 const CheckIcon: React.FC<{ className?: string }> = ({ className }) => (
@@ -86,7 +102,7 @@ const LicenseUpgradeDialog: React.FC<LicenseUpgradeDialogProps> = ({
     <div className={`fixed inset-0 z-50 flex items-center justify-center p-4 transition-opacity duration-200 ${mounted ? 'opacity-100' : 'opacity-0'}`}>
       {/* Backdrop */}
       <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
-      
+
       {/* Dialog */}
       <div className={`relative w-full max-w-4xl bg-gradient-to-b from-slate-800 to-slate-900 rounded-2xl border border-slate-700 shadow-2xl overflow-hidden transform transition-all duration-200 ${mounted ? 'opacity-100 scale-100' : 'opacity-0 scale-95'}`}>
         {/* Header with gradient */}
@@ -100,7 +116,7 @@ const LicenseUpgradeDialog: React.FC<LicenseUpgradeDialogProps> = ({
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
-          
+
           <div className="flex items-center gap-4">
             <div className="w-14 h-14 rounded-xl bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center shadow-lg">
               <svg className="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -111,14 +127,10 @@ const LicenseUpgradeDialog: React.FC<LicenseUpgradeDialogProps> = ({
               <h2 className="text-2xl font-bold text-white">Upgrade to Unlock</h2>
               <p className="text-slate-300 mt-1">
                 <span className="font-semibold text-blue-400">{featureName}</span> requires a{' '}
-                <span className="font-semibold text-purple-400">{TIER_DISPLAY_NAMES[requiredTier]}</span> license or above
+                <span className="font-semibold text-purple-400">{TIER_DISPLAY_NAMES[requiredTier]}</span> plan or above
               </p>
             </div>
           </div>
-          
-          {featureDescription && (
-            <p className="mt-4 text-slate-400 text-sm max-w-2xl">{featureDescription}</p>
-          )}
         </div>
 
         {/* Comparison Table */}
@@ -129,12 +141,12 @@ const LicenseUpgradeDialog: React.FC<LicenseUpgradeDialogProps> = ({
                 <tr className="border-b border-slate-700">
                   <th className="text-left py-4 px-4 text-slate-300 font-medium">Feature</th>
                   <th className="text-center py-4 px-4 min-w-[100px]">
-                    <div className="text-slate-300 font-medium">Community</div>
+                    <div className="text-slate-300 font-medium">Individual</div>
                     <div className="text-sm text-slate-500">Free</div>
                   </th>
                   <th className="text-center py-4 px-4 min-w-[100px]">
                     <div className="relative">
-                      <div className="text-blue-400 font-bold">Team</div>
+                      <div className="text-blue-400 font-bold">Premium</div>
                       <div className="text-sm text-blue-300/70">Recommended</div>
                       {requiredTier === 'team' && (
                         <div className="absolute -top-2 -right-2 w-4 h-4 bg-blue-500 rounded-full animate-pulse" />
@@ -149,11 +161,10 @@ const LicenseUpgradeDialog: React.FC<LicenseUpgradeDialogProps> = ({
               </thead>
               <tbody>
                 {FEATURE_COMPARISON.map((row) => (
-                  <tr 
-                    key={row.feature} 
-                    className={`border-b border-slate-800 transition-colors ${
-                      row.feature === featureName ? 'bg-blue-500/10' : 'hover:bg-slate-800/50'
-                    }`}
+                  <tr
+                    key={row.feature}
+                    className={`border-b border-slate-800 transition-colors ${row.feature === featureName ? 'bg-blue-500/10' : 'hover:bg-slate-800/50'
+                      }`}
                   >
                     <td className="py-3 px-4 text-slate-200 text-sm">
                       {row.feature}
@@ -164,10 +175,10 @@ const LicenseUpgradeDialog: React.FC<LicenseUpgradeDialogProps> = ({
                       )}
                     </td>
                     <td className="py-3 px-4 text-center">
-                      {row.community ? <CheckIcon /> : <XIcon />}
+                      {row.individual ? <CheckIcon /> : <XIcon />}
                     </td>
                     <td className="py-3 px-4 text-center">
-                      {row.team ? <CheckIcon className="w-5 h-5 text-blue-400" /> : <XIcon />}
+                      {row.premium ? <CheckIcon className="w-5 h-5 text-blue-400" /> : <XIcon />}
                     </td>
                     <td className="py-3 px-4 text-center">
                       {row.enterprise ? <CheckIcon className="w-5 h-5 text-purple-400" /> : <XIcon />}
@@ -183,7 +194,7 @@ const LicenseUpgradeDialog: React.FC<LicenseUpgradeDialogProps> = ({
         <div className="px-6 py-5 bg-slate-800/50 border-t border-slate-700">
           <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
             <p className="text-slate-400 text-sm">
-              Unlock the full potential of LiveReview for your team
+              Unlock the full potential of LiveReview Premium
             </p>
             <div className="flex items-center gap-3">
               <button
@@ -193,15 +204,13 @@ const LicenseUpgradeDialog: React.FC<LicenseUpgradeDialogProps> = ({
                 Maybe Later
               </button>
               <a
-                href="https://hexmos.com/livereview/selfhosted-access/"
-                target="_blank"
-                rel="noopener noreferrer"
+                href="#/settings-subscriptions-overview"
                 className="px-5 py-2.5 text-sm font-medium rounded-lg bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 text-white transition-all shadow-lg hover:shadow-xl hover:shadow-purple-500/25 flex items-center gap-2"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                 </svg>
-                Get License
+                Upgrade Plan
               </a>
             </div>
           </div>

--- a/ui/src/components/UIPrimitives.tsx
+++ b/ui/src/components/UIPrimitives.tsx
@@ -1009,7 +1009,7 @@ export const Spinner: React.FC<SpinnerProps> = ({
 // ===== TOOLTIP COMPONENT =====
 interface TooltipProps {
   children: ReactNode;
-  content: string;
+  content: ReactNode;
   position?: 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'auto';
   className?: string;
 }

--- a/ui/src/components/UserManagement/UserList.tsx
+++ b/ui/src/components/UserManagement/UserList.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
-import { Button, Tooltip } from '../UIPrimitives';
+import { Button, Tooltip, Popover } from '../UIPrimitives';
 import { Member } from '../../api/users';
 import { useOrgContext } from '../../hooks/useOrgContext';
 
@@ -223,11 +223,24 @@ export const UserList: React.FC<UserListProps> = ({
                             <th className="px-6 py-3 text-center text-xs font-medium text-slate-400 uppercase tracking-wider">
                                 <div className="flex items-center justify-center gap-1">
                                     git-lrc Access
-                                    <Tooltip content="On the Free plan, reviews can only be triggered via the git-lrc CLI by the org owner. Dashboard triggers require Premium." position="top">
-                                        <svg className="w-4 h-4 text-slate-500 hover:text-slate-300 transition-colors cursor-help cursor-pointer" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                        </svg>
-                                    </Tooltip>
+                                    {isFreePlan && (
+                                        <Popover 
+                                            hover={true} 
+                                            align="center"
+                                            trigger={
+                                                <svg className="w-4 h-4 text-slate-500 hover:text-slate-300 transition-colors cursor-help cursor-pointer" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                </svg>
+                                            }
+                                        >
+                                            <p>
+                                                On the Free plan, reviews can only be triggered via the git-lrc CLI by the org owner. Dashboard triggers require Premium.{' '}
+                                                <a href="/#/settings-subscriptions-overview" className="text-blue-300 hover:text-blue-200 underline">
+                                                    Upgrade to Premium
+                                                </a>
+                                            </p>
+                                        </Popover>
+                                    )}
                                 </div>
                             </th>
                             {isSuperAdminView && (

--- a/ui/src/components/UserManagement/UserList.tsx
+++ b/ui/src/components/UserManagement/UserList.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
-import { Button } from '../UIPrimitives';
+import { Button, Tooltip } from '../UIPrimitives';
 import { Member } from '../../api/users';
 import { useOrgContext } from '../../hooks/useOrgContext';
 
@@ -57,7 +57,7 @@ export const UserList: React.FC<UserListProps> = ({
     onTransferUser,
     onRefresh,
 }) => {
-    const { currentOrg } = useOrgContext();
+    const { currentOrg, isFreePlan } = useOrgContext();
     const [selectedUsers, setSelectedUsers] = useState<Set<number>>(new Set());
 
     // Clear selection when users change
@@ -220,6 +220,16 @@ export const UserList: React.FC<UserListProps> = ({
                             <th className="px-6 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">
                                 Role
                             </th>
+                            <th className="px-6 py-3 text-center text-xs font-medium text-slate-400 uppercase tracking-wider">
+                                <div className="flex items-center justify-center gap-1">
+                                    git-lrc Access
+                                    <Tooltip content="On the Free plan, reviews can only be triggered via the git-lrc CLI by the org owner. Dashboard triggers require Premium." position="top">
+                                        <svg className="w-4 h-4 text-slate-500 hover:text-slate-300 transition-colors cursor-help cursor-pointer" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                        </svg>
+                                    </Tooltip>
+                                </div>
+                            </th>
                             {isSuperAdminView && (
                                 <th className="px-6 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">
                                     Organizations
@@ -277,6 +287,19 @@ export const UserList: React.FC<UserListProps> = ({
                                 </td>
                                 <td className="px-6 py-4 text-sm text-slate-400 capitalize">
                                     {user.role}
+                                </td>
+                                <td className="px-6 py-4">
+                                    <div className="flex justify-center">
+                                        {(!isFreePlan || currentOrg?.created_by_user_id === user.id) ? (
+                                            <svg className="w-5 h-5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-label="Has Review Access">
+                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+                                            </svg>
+                                        ) : (
+                                            <svg className="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-label="No Review Access">
+                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                            </svg>
+                                        )}
+                                    </div>
                                 </td>
                                 {isSuperAdminView && (
                                     <td className="px-6 py-4">

--- a/ui/src/components/UserManagement/UserManagement.tsx
+++ b/ui/src/components/UserManagement/UserManagement.tsx
@@ -21,7 +21,7 @@ export interface UserManagementProps {
 export const UserManagement: React.FC<UserManagementProps> = ({
     isSuperAdminView = false,
 }) => {
-    const { currentOrg, isSuperAdmin, canManageCurrentOrg } = useOrgContext();
+    const { currentOrg, isSuperAdmin, canManageCurrentOrg, isFreePlan } = useOrgContext();
     const license = useSelector((state: RootState) => state.License);
     const navigate = useNavigate();
     const [users, setUsers] = useState<Member[]>([]);
@@ -158,7 +158,7 @@ export const UserManagement: React.FC<UserManagementProps> = ({
             </div>
 
             {/* Free Plan Info Banner - Cloud only */}
-            {isCloudMode() && !isSuperAdminView && currentOrg?.plan_type === 'free' && (
+            {isCloudMode() && !isSuperAdminView && isFreePlan && (
                 <div className="bg-blue-900/20 border border-blue-500/30 rounded-lg p-4">
                     <div className="flex items-start">
                         <svg className="w-5 h-5 text-blue-400 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -167,8 +167,8 @@ export const UserManagement: React.FC<UserManagementProps> = ({
                         <div className="flex-1">
                             <h3 className="text-blue-200 font-semibold mb-1">Free Plan Limitations</h3>
                             <p className="text-blue-100/80 text-sm mb-2">
-                                You can add members to your organization, but on the Free plan only the organization creator has access. 
-                                Added members won't be able to access reviews or trigger new reviews.
+                                On the Free plan, only the organization creator can trigger reviews via the git-lrc CLI. Dashboard triggers require Premium. 
+                                Added members cannot trigger reviews.
                             </p>
                             <p className="text-blue-100/80 text-sm">
                                 <Link to="/subscribe" className="text-blue-300 hover:text-blue-200 underline font-medium">

--- a/ui/src/components/UserManagement/UserManagement.tsx
+++ b/ui/src/components/UserManagement/UserManagement.tsx
@@ -35,12 +35,12 @@ export const UserManagement: React.FC<UserManagementProps> = ({
 
     // Load users
     const loadUsers = useCallback(async () => {
-        console.log('[UserManagement] loadUsers called', { 
-            orgId: currentOrg?.id, 
-            isSuperAdminView, 
-            isSuperAdmin 
+        console.log('[UserManagement] loadUsers called', {
+            orgId: currentOrg?.id,
+            isSuperAdminView,
+            isSuperAdmin
         });
-        
+
         if (isSuperAdminView && !isSuperAdmin) {
             setError('Access denied: Super admin privileges required');
             return;
@@ -54,7 +54,7 @@ export const UserManagement: React.FC<UserManagementProps> = ({
 
         setLoading(true);
         setError(null);
-        
+
         try {
             if (isSuperAdminView) {
                 // TODO: Implement super admin user fetching
@@ -116,7 +116,7 @@ export const UserManagement: React.FC<UserManagementProps> = ({
                         {isSuperAdminView ? 'All Users (Super Admin)' : 'User Management'}
                     </h2>
                     <p className="text-slate-400 mt-1">
-                        {isSuperAdminView 
+                        {isSuperAdminView
                             ? 'Manage users across all organizations'
                             : `Manage users in ${currentOrg?.name || 'your organization'}`
                         }
@@ -126,15 +126,15 @@ export const UserManagement: React.FC<UserManagementProps> = ({
                             Organization created on {new Date(currentOrg.created_at).toLocaleDateString()}
                             {currentOrg.creator_email && (
                                 <> by {
-                                    currentOrg.creator_first_name && currentOrg.creator_last_name 
-                                        ? `${currentOrg.creator_first_name} ${currentOrg.creator_last_name}` 
+                                    currentOrg.creator_first_name && currentOrg.creator_last_name
+                                        ? `${currentOrg.creator_first_name} ${currentOrg.creator_last_name}`
                                         : currentOrg.creator_email
                                 }</>
                             )}
                         </p>
                     )}
                 </div>
-                
+
                 {canManageUsers && (
                     <Button
                         variant="primary"
@@ -166,15 +166,9 @@ export const UserManagement: React.FC<UserManagementProps> = ({
                         </svg>
                         <div className="flex-1">
                             <h3 className="text-blue-200 font-semibold mb-1">Free Plan Limitations</h3>
-                            <p className="text-blue-100/80 text-sm mb-2">
-                                On the Free plan, only the organization creator can trigger reviews via the git-lrc CLI. Dashboard triggers require Premium. 
-                                Added members cannot trigger reviews.
-                            </p>
                             <p className="text-blue-100/80 text-sm">
-                                <Link to="/subscribe" className="text-blue-300 hover:text-blue-200 underline font-medium">
-                                    Upgrade to Team Plan
-                                </Link>
-                                {' '}to give all team members full access with unlimited reviews.
+                                On the Free plan, only the organization creator can trigger reviews via the git-lrc CLI. Dashboard triggers require Premium.
+                                Added members cannot trigger reviews. <a href="/#/settings-subscriptions-overview" className="text-blue-300 hover:text-blue-200 underline font-medium">Upgrade to Premium</a> to give all members full access.
                             </p>
                         </div>
                     </div>
@@ -189,7 +183,7 @@ export const UserManagement: React.FC<UserManagementProps> = ({
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
                         </svg>
                         <p className="text-yellow-300">
-                            You can view users in this organization but don't have permission to manage them. 
+                            You can view users in this organization but don't have permission to manage them.
                             Contact an organization owner for management capabilities.
                         </p>
                     </div>

--- a/ui/src/constants/licenseTiers.ts
+++ b/ui/src/constants/licenseTiers.ts
@@ -28,8 +28,8 @@ export const TIER_ORDER: Record<LicenseTier, number> = {
  * Display names for tiers
  */
 export const TIER_DISPLAY_NAMES: Record<LicenseTier, string> = {
-  community: 'Community',
-  team: 'Team',
+  community: 'Free',
+  team: 'Premium',
   enterprise: 'Enterprise',
 };
 

--- a/ui/src/hooks/useOrgContext.tsx
+++ b/ui/src/hooks/useOrgContext.tsx
@@ -135,5 +135,6 @@ export const useOrgContext = () => {
         hasOrganizations: userOrganizations.length > 0,
         canCreateOrgs: isSuperAdmin,
                 canManageCurrentOrg: currentOrg?.role === 'owner' || isSuperAdmin,
+        isFreePlan: currentOrg?.plan_type === 'free_30k',
     };
 };

--- a/ui/src/pages/GitProviders/GitProviders.tsx
+++ b/ui/src/pages/GitProviders/GitProviders.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Routes, Route, useNavigate } from 'react-router-dom';
+import classNames from 'classnames';
 import { formatDistanceToNow, format } from 'date-fns';
 import ConnectorForm from '../../components/Connector/ConnectorForm';
 import ProviderSelection from '../../components/Connector/ProviderSelection';
@@ -14,9 +15,11 @@ import {
     Badge,
     Avatar,
     Spinner,
-    Tooltip
+    Tooltip,
+    Alert
 } from '../../components/UIPrimitives';
 import { getConnectors, ConnectorResponse, deleteConnector, WebhookStatusSummary } from '../../api/connectors';
+import { useOrgContext } from '../../hooks/useOrgContext';
 import ConnectorDetails from './ConnectorDetails';
 
 // Spec for GitProviderKit
@@ -67,6 +70,8 @@ const GitProvidersList: React.FC = () => {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
     const storeConnectors = useAppSelector((state) => state.Connector.connectors);
+    const { isFreePlan, isSuperAdmin } = useOrgContext();
+    const isReadOnly = isFreePlan && !isSuperAdmin;
     
     // Use redux state only for connectors
     const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -231,7 +236,12 @@ const GitProvidersList: React.FC = () => {
             />
             
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-                <div>
+                <div className={classNames(isReadOnly && "opacity-60 pointer-events-none")}>
+                    {isReadOnly && (
+                        <Alert variant="info" className="mb-4">
+                            Connectors are read-only on the Free plan. Upgrade to add or remove providers.
+                        </Alert>
+                    )}
                     <ProviderSelection />
                     
                     {/* Brand Showcase */}
@@ -334,9 +344,9 @@ const GitProvidersList: React.FC = () => {
                                                         variant="outline"
                                                         size="sm"
                                                         onClick={() => handleDeleteConnector(connector.id, connector.name)}
-                                                        disabled={isLoading}
-                                                        title="Delete connector"
-                                                        className="!px-2.5 !text-red-400 hover:!text-red-300 hover:!border-red-400"
+                                                        disabled={isLoading || isReadOnly}
+                                                        title={isReadOnly ? "Upgrade to delete connectors" : "Delete connector"}
+                                                        className="!px-2.5 !text-red-400 hover:!text-red-300 hover:!border-red-400 disabled:opacity-50"
                                                     >
                                                         <Icons.Delete />
                                                     </Button>

--- a/ui/src/pages/GitProviders/GitProviders.tsx
+++ b/ui/src/pages/GitProviders/GitProviders.tsx
@@ -18,6 +18,7 @@ import {
     Tooltip,
     Alert
 } from '../../components/UIPrimitives';
+import LicenseUpgradeDialog from '../../components/License/LicenseUpgradeDialog';
 import { getConnectors, ConnectorResponse, deleteConnector, WebhookStatusSummary } from '../../api/connectors';
 import { useOrgContext } from '../../hooks/useOrgContext';
 import ConnectorDetails from './ConnectorDetails';
@@ -72,6 +73,7 @@ const GitProvidersList: React.FC = () => {
     const storeConnectors = useAppSelector((state) => state.Connector.connectors);
     const { isFreePlan, isSuperAdmin } = useOrgContext();
     const isReadOnly = isFreePlan && !isSuperAdmin;
+    const [showUpgradeDialog, setShowUpgradeDialog] = useState(false);
     
     // Use redux state only for connectors
     const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -236,13 +238,20 @@ const GitProvidersList: React.FC = () => {
             />
             
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-                <div className={classNames(isReadOnly && "opacity-60 pointer-events-none")}>
+                <div 
+                    className={classNames(isReadOnly && "cursor-pointer")}
+                    onClick={() => {
+                        if (isReadOnly) setShowUpgradeDialog(true);
+                    }}
+                >
                     {isReadOnly && (
                         <Alert variant="info" className="mb-4">
-                            Connectors are read-only on the Free plan. Upgrade to add or remove providers.
+                            Connectors are read-only on the Free plan. Click to see upgrade options.
                         </Alert>
                     )}
-                    <ProviderSelection />
+                    <div className={classNames(isReadOnly && "pointer-events-none")}>
+                        <ProviderSelection />
+                    </div>
                     
                     {/* Brand Showcase */}
                     <div className="mt-6 card-brand rounded-lg bg-slate-700 border border-slate-600 p-5 shadow-md">
@@ -343,10 +352,17 @@ const GitProvidersList: React.FC = () => {
                                                     <Button
                                                         variant="outline"
                                                         size="sm"
-                                                        onClick={() => handleDeleteConnector(connector.id, connector.name)}
-                                                        disabled={isLoading || isReadOnly}
+                                                        onClick={(e) => {
+                                                            e.stopPropagation();
+                                                            if (isReadOnly) {
+                                                                setShowUpgradeDialog(true);
+                                                            } else {
+                                                                handleDeleteConnector(connector.id, connector.name);
+                                                            }
+                                                        }}
+                                                        disabled={isLoading}
                                                         title={isReadOnly ? "Upgrade to delete connectors" : "Delete connector"}
-                                                        className="!px-2.5 !text-red-400 hover:!text-red-300 hover:!border-red-400 disabled:opacity-50"
+                                                        className="!px-2.5 !text-red-400 hover:!text-red-300 hover:!border-red-400"
                                                     >
                                                         <Icons.Delete />
                                                     </Button>
@@ -360,6 +376,15 @@ const GitProvidersList: React.FC = () => {
                     </Card>
                 </div>
             </div>
+            
+            {/* Upgrade Modal */}
+            <LicenseUpgradeDialog
+                open={showUpgradeDialog}
+                onClose={() => setShowUpgradeDialog(false)}
+                requiredTier="team"
+                featureName="Git Provider Management"
+                featureDescription="Upgrade to a paid plan to add, remove, and manage your Git provider configurations."
+            />
         </div>
     );
 };

--- a/ui/src/pages/Reviews/NewReview.tsx
+++ b/ui/src/pages/Reviews/NewReview.tsx
@@ -18,6 +18,7 @@ import { SafetyBanner } from '../../components/SafetyBanner/SafetyBanner';
 import apiClient from '../../api/apiClient';
 import { QuotaExhaustedBanner } from '../../components/Dashboard/QuotaExhaustedBanner';
 import { QuotaWarningBanner } from '../../components/Dashboard/QuotaWarningBanner';
+import { useOrgContext } from '../../hooks/useOrgContext';
 
 type QuotaStatusResponse = {
   can_trigger_reviews: boolean;
@@ -36,6 +37,8 @@ type QuotaStatusResponse = {
 
 const NewReview: React.FC = () => {
   const navigate = useNavigate();
+  const { isFreePlan, isSuperAdmin } = useOrgContext();
+  const isReadOnly = isFreePlan && !isSuperAdmin;
   const [url, setUrl] = useState('');
   const [connectors, setConnectors] = useState<ConnectorResponse[]>([]);
   const [loading, setLoading] = useState(false);
@@ -249,8 +252,8 @@ const NewReview: React.FC = () => {
                 />
               )}
 
-              {/* Blocked / Trial Read-Only Banner */}
-              {(quotaStatus?.envelope?.trial_readonly || quotaStatus?.envelope?.blocked || quotaStatus?.can_trigger_reviews === false) && (
+              {/* Blocked / Trial Read-Only / Free Plan Read-Only Banner */}
+              {(isReadOnly || quotaStatus?.envelope?.trial_readonly || quotaStatus?.envelope?.blocked || quotaStatus?.can_trigger_reviews === false) && (
                 <Alert
                   variant="error"
                   className="mb-4"
@@ -258,12 +261,14 @@ const NewReview: React.FC = () => {
                 >
                   <div>
                     <div className="font-medium text-red-100">
-                      {quotaStatus?.envelope?.trial_readonly ? 'Trial Read-Only Active' : 'Monthly LOC Quota Exceeded'}
+                      {isReadOnly ? 'Free Plan Read-Only Mode' : (quotaStatus?.envelope?.trial_readonly ? 'Trial Read-Only Active' : 'Monthly LOC Quota Exceeded')}
                     </div>
                     <div className="text-sm mt-1 text-red-200/90">
-                      {quotaStatus?.envelope?.trial_readonly
-                        ? 'This organization is in trial read-only mode. Upgrade from Subscription Management to continue triggering reviews.'
-                        : `You've used ${(quotaStatus?.envelope?.loc_used_month ?? 0).toLocaleString()} of ${(quotaStatus?.envelope?.loc_limit_month ?? 0).toLocaleString()} LOC this month. Reviews are blocked until your quota resets${quotaStatus?.envelope?.billing_period_end ? ` on ${new Date(quotaStatus.envelope.billing_period_end).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}` : ''} or you upgrade your plan.`}
+                      {isReadOnly 
+                        ? 'Review creation is not available on the Free plan. Upgrade to a paid plan to start using AI code reviews.'
+                        : (quotaStatus?.envelope?.trial_readonly
+                          ? 'This organization is in trial read-only mode. Upgrade from Subscription Management to continue triggering reviews.'
+                          : `You've used ${(quotaStatus?.envelope?.loc_used_month ?? 0).toLocaleString()} of ${(quotaStatus?.envelope?.loc_limit_month ?? 0).toLocaleString()} LOC this month. Reviews are blocked until your quota resets${quotaStatus?.envelope?.billing_period_end ? ` on ${new Date(quotaStatus.envelope.billing_period_end).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}` : ''} or you upgrade your plan.`)}
                     </div>
                     <button
                       type="button"
@@ -343,6 +348,7 @@ const NewReview: React.FC = () => {
                   disabled={
                     loading ||
                     !url.trim() ||
+                    isReadOnly ||
                     Boolean(quotaStatus?.envelope?.blocked) ||
                     Boolean(quotaStatus?.envelope?.trial_readonly) ||
                     (quotaStatus?.envelope?.usage_percent ?? 0) >= 100 ||

--- a/ui/src/pages/Reviews/NewReview.tsx
+++ b/ui/src/pages/Reviews/NewReview.tsx
@@ -19,6 +19,7 @@ import apiClient from '../../api/apiClient';
 import { QuotaExhaustedBanner } from '../../components/Dashboard/QuotaExhaustedBanner';
 import { QuotaWarningBanner } from '../../components/Dashboard/QuotaWarningBanner';
 import { useOrgContext } from '../../hooks/useOrgContext';
+import LicenseUpgradeDialog from '../../components/License/LicenseUpgradeDialog';
 
 type QuotaStatusResponse = {
   can_trigger_reviews: boolean;
@@ -49,6 +50,7 @@ const NewReview: React.FC = () => {
   const [upgradeReason, setUpgradeReason] = useState<'DAILY_LIMIT' | 'NOT_ORG_CREATOR'>('DAILY_LIMIT');
   const [limitInfo, setLimitInfo] = useState<{ used: number; limit: number }>({ used: 3, limit: 3 });
   const [quotaStatus, setQuotaStatus] = useState<QuotaStatusResponse | null>(null);
+  const [showPlanUpgradeDialog, setShowPlanUpgradeDialog] = useState(false);
 
   // Load connectors when component mounts
   useEffect(() => {
@@ -99,6 +101,10 @@ const NewReview: React.FC = () => {
   // Handle form submission
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isReadOnly) {
+      setShowPlanUpgradeDialog(true);
+      return;
+    }
     setError(null);
     setSuccess(null);
 
@@ -348,7 +354,6 @@ const NewReview: React.FC = () => {
                   disabled={
                     loading ||
                     !url.trim() ||
-                    isReadOnly ||
                     Boolean(quotaStatus?.envelope?.blocked) ||
                     Boolean(quotaStatus?.envelope?.trial_readonly) ||
                     (quotaStatus?.envelope?.usage_percent ?? 0) >= 100 ||
@@ -370,6 +375,15 @@ const NewReview: React.FC = () => {
           reason={upgradeReason}
           currentCount={limitInfo.used}
           limit={limitInfo.limit}
+        />
+        
+        {/* Plan Upgrade Dialog */}
+        <LicenseUpgradeDialog
+          open={showPlanUpgradeDialog}
+          onClose={() => setShowPlanUpgradeDialog(false)}
+          requiredTier="team"
+          featureName="Review Creation from Dashboard"
+          featureDescription="Upgrade to a paid plan to trigger new AI code reviews. Free plans are read-only."
         />
       </div>
     </ErrorBoundary>

--- a/ui/src/pages/Settings/Settings.tsx
+++ b/ui/src/pages/Settings/Settings.tsx
@@ -298,9 +298,9 @@ const Settings = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a4 4 0 10-4 4v1a1 1 0 001 1h1v1a1 1 0 001 1h1l3 3 3-3-3-3v-2a4 4 0 00-4-4z" />
             </svg>
         ) }] : []),
-        ...(canAccessPrompts && !(isFreePlan && !isSuperAdmin) ? [{ id: 'prompts', name: 'Prompts', icon: <Icons.AI /> }] : []),
+        ...(canAccessPrompts ? [{ id: 'prompts', name: 'Prompts', icon: <Icons.AI /> }] : []),
         // Learnings tab visible to all org members
-        ...((isSuperAdmin || currentOrg) && !(isFreePlan && !isSuperAdmin) ? [{ id: 'learnings', name: 'Learnings', icon: <Icons.List /> }] : []),
+        ...((isSuperAdmin || currentOrg) ? [{ id: 'learnings', name: 'Learnings', icon: <Icons.List /> }] : []),
         // API Keys tab visible to all org members
         ...((isSuperAdmin || currentOrg) ? [{ 
             id: 'api-keys', 
@@ -312,7 +312,7 @@ const Settings = () => {
             )
         }] : []),
         // User Management tab visible to all org members (read-only for non-owners)
-        ...((isSuperAdmin || currentOrg) && !(isFreePlan && !isSuperAdmin) ? [{ 
+        ...((isSuperAdmin || currentOrg) ? [{ 
             id: 'users', 
             name: 'User Management', 
             icon: (

--- a/ui/src/pages/Settings/Settings.tsx
+++ b/ui/src/pages/Settings/Settings.tsx
@@ -262,7 +262,7 @@ const Settings = () => {
     const location = useLocation();
     const navigate = useNavigate();
     const { domain } = useAppSelector((state) => state.Settings);
-    const { isSuperAdmin, canManageCurrentOrg, currentOrg } = useOrgContext();
+    const { isSuperAdmin, canManageCurrentOrg, currentOrg, isFreePlan } = useOrgContext();
     const canAccessPrompts = isSuperAdmin || (currentOrg && ['owner', 'member'].includes(currentOrg.role));
     
     // Check if we're on a subscription sub-route
@@ -298,9 +298,9 @@ const Settings = () => {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a4 4 0 10-4 4v1a1 1 0 001 1h1v1a1 1 0 001 1h1l3 3 3-3-3-3v-2a4 4 0 00-4-4z" />
             </svg>
         ) }] : []),
-        ...(canAccessPrompts ? [{ id: 'prompts', name: 'Prompts', icon: <Icons.AI /> }] : []),
+        ...(canAccessPrompts && !(isFreePlan && !isSuperAdmin) ? [{ id: 'prompts', name: 'Prompts', icon: <Icons.AI /> }] : []),
         // Learnings tab visible to all org members
-        ...((isSuperAdmin || currentOrg) ? [{ id: 'learnings', name: 'Learnings', icon: <Icons.List /> }] : []),
+        ...((isSuperAdmin || currentOrg) && !(isFreePlan && !isSuperAdmin) ? [{ id: 'learnings', name: 'Learnings', icon: <Icons.List /> }] : []),
         // API Keys tab visible to all org members
         ...((isSuperAdmin || currentOrg) ? [{ 
             id: 'api-keys', 
@@ -312,7 +312,7 @@ const Settings = () => {
             )
         }] : []),
         // User Management tab visible to all org members (read-only for non-owners)
-        ...((isSuperAdmin || currentOrg) ? [{ 
+        ...((isSuperAdmin || currentOrg) && !(isFreePlan && !isSuperAdmin) ? [{ 
             id: 'users', 
             name: 'User Management', 
             icon: (


### PR DESCRIPTION
- Free plan enforcement in dashboard.
- For free plan users, they can trigger only git-lrc, with no direct review from the dashboard.
- Restrict connecting to a Git provider for free plan users.