### PR TITLE
Update Docker build base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Creates a lightweight container with UI + Backend
 
 # Stage 1: Build React UI
-FROM node:18-alpine AS ui-builder
+FROM node:20-alpine AS ui-builder
 WORKDIR /app/ui
 
 # Copy package files and install dependencies
@@ -26,7 +26,7 @@ RUN echo "✅ Verifying UI build output..." && \
     echo "UI build completed successfully"
 
 # Stage 2: Build Go binary with embedded UI
-FROM golang:1.24-alpine AS go-builder
+FROM golang:1.25-alpine AS go-builder
 
 # Platform arguments for multi-arch builds
 ARG TARGETPLATFORM

--- a/Dockerfile.crosscompile
+++ b/Dockerfile.crosscompile
@@ -3,7 +3,7 @@
 # Fully Dockerized: builds UI and Go binaries in Docker, then assembles runtime image.
 
 # Stage 1: Build React UI once (architecture-agnostic)
-FROM --platform=$BUILDPLATFORM node:18-alpine AS ui-builder
+FROM --platform=$BUILDPLATFORM node:20-alpine AS ui-builder
 WORKDIR /app/ui
 
 # Copy package files and install dependencies
@@ -21,7 +21,7 @@ RUN echo "🔨 Building UI for SELF-HOSTED deployment (is_cloud=false)..." && \
     echo "✅ UI build completed successfully"
 
 # Stage 2: Cross-compile all binaries for all architectures in one stage
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 # Accept target platform args (injected by buildx)
 ARG TARGETOS


### PR DESCRIPTION
## Summary
- update Docker UI build stages from Node 18 to Node 20
- update Go build stages from Go 1.24 to Go 1.25
- keep both the normal and cross-compilation Dockerfiles aligned

## Why
The current codebase has newer build requirements than the Dockerfiles provide:
- `go.mod` declares `go 1.25.10`, while Docker was using `golang:1.24-alpine`
- the UI lockfile includes dependencies that require Node 20+, while Docker was using `node:18-alpine`

This should address #53 by bringing the Docker build images up to the versions expected by the current source tree.

## Validation
- `git diff --check`
- confirmed `go.mod` declares `go 1.25.10`
- checked `ui/package-lock.json` for dependencies requiring Node 20+

Note: I could not run a full Docker build locally because this environment does not have the `docker` CLI installed.