### PR TITLE
Add Anthropic Compatible API Support for BYOK

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,4 +1,4 @@
-\restrict anSYBH9t8UbforiiJZ5gMlI42AnQUeSn1gSuyq1AkSvE615Agr3aFj3hnIpg6Yn
+\restrict 5j42kSOAclS9gH7M4nfj1b5ibOlParLbh4bORLlbi5Zw5KKfVl5kOzdpvDTVZAO
 
 -- Dumped from database version 14.22 (Ubuntu 14.22-0ubuntu0.22.04.1)
 -- Dumped by pg_dump version 14.22 (Ubuntu 14.22-0ubuntu0.22.04.1)
@@ -48,6 +48,20 @@ CREATE TYPE public.river_job_state AS ENUM (
     'running',
     'scheduled'
 );
+
+
+--
+-- Name: ai_models_set_updated_at(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.ai_models_set_updated_at() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$;
 
 
 --
@@ -266,6 +280,43 @@ CREATE SEQUENCE public.ai_connectors_id_seq
 --
 
 ALTER SEQUENCE public.ai_connectors_id_seq OWNED BY public.ai_connectors.id;
+
+
+--
+-- Name: ai_models; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ai_models (
+    id integer NOT NULL,
+    model_id character varying(255) NOT NULL,
+    provider character varying(50) NOT NULL,
+    name character varying(255) NOT NULL,
+    is_active boolean DEFAULT true,
+    is_default boolean DEFAULT false,
+    metadata jsonb,
+    created_at timestamp without time zone DEFAULT now(),
+    updated_at timestamp without time zone DEFAULT now()
+);
+
+
+--
+-- Name: ai_models_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ai_models_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ai_models_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ai_models_id_seq OWNED BY public.ai_models.id;
 
 
 --
@@ -2130,6 +2181,13 @@ ALTER TABLE ONLY public.ai_connectors ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: ai_models id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ai_models ALTER COLUMN id SET DEFAULT nextval('public.ai_models_id_seq'::regclass);
+
+
+--
 -- Name: api_keys id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2388,6 +2446,22 @@ ALTER TABLE ONLY public.ai_comments
 
 ALTER TABLE ONLY public.ai_connectors
     ADD CONSTRAINT ai_connectors_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ai_models ai_models_model_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ai_models
+    ADD CONSTRAINT ai_models_model_id_key UNIQUE (model_id);
+
+
+--
+-- Name: ai_models ai_models_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ai_models
+    ADD CONSTRAINT ai_models_pkey PRIMARY KEY (id);
 
 
 --
@@ -2994,6 +3068,13 @@ CREATE INDEX idx_ai_connectors_org_provider ON public.ai_connectors USING btree 
 --
 
 CREATE INDEX idx_ai_connectors_provider_name ON public.ai_connectors USING btree (provider_name);
+
+
+--
+-- Name: idx_ai_models_provider; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_ai_models_provider ON public.ai_models USING btree (provider);
 
 
 --
@@ -3998,6 +4079,13 @@ CREATE UNIQUE INDEX ux_license_state_singleton ON public.license_state USING btr
 
 
 --
+-- Name: ai_models trg_ai_models_updated_at; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_ai_models_updated_at BEFORE UPDATE ON public.ai_models FOR EACH ROW EXECUTE FUNCTION public.ai_models_set_updated_at();
+
+
+--
 -- Name: license_seat_assignments trg_license_seat_assignments_updated_at; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -4713,7 +4801,7 @@ ALTER TABLE ONLY public.webhook_registry
 -- PostgreSQL database dump complete
 --
 
-\unrestrict anSYBH9t8UbforiiJZ5gMlI42AnQUeSn1gSuyq1AkSvE615Agr3aFj3hnIpg6Yn
+\unrestrict 5j42kSOAclS9gH7M4nfj1b5ibOlParLbh4bORLlbi5Zw5KKfVl5kOzdpvDTVZAO
 
 
 --
@@ -4786,4 +4874,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260420140334'),
     ('20260521120000'),
     ('20260521140000'),
-    ('20260522120000');
+    ('20260522120000'),
+    ('20260527120000');

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -212,6 +212,23 @@ paths:
           description: Bad Request
       tags:
         - Aiconnectors
+  /api/v1/aiconnectors/providers/{provider}/models:
+    get:
+      description: GetAIProviderModels handles requests to get all active models for a specific AI provider
+      operationId: GetAIProviderModels
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+      responses:
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
+      tags:
+        - Aiconnectors
   /api/v1/aiconnectors/reorder:
     put:
       description: ReorderAIConnectors handles requests to reorder AI connectors
@@ -1352,12 +1369,12 @@ paths:
       operationId: UpdateUser
       parameters:
         - in: path
-          name: org_id
+          name: user_id
           required: true
           schema:
             type: string
         - in: path
-          name: user_id
+          name: org_id
           required: true
           schema:
             type: string
@@ -1372,12 +1389,12 @@ paths:
       operationId: GetUserAuditLog
       parameters:
         - in: path
-          name: org_id
+          name: user_id
           required: true
           schema:
             type: string
         - in: path
-          name: user_id
+          name: org_id
           required: true
           schema:
             type: string
@@ -1928,12 +1945,12 @@ paths:
       operationId: RevokeLicense
       parameters:
         - in: path
-          name: id
+          name: user_id
           required: true
           schema:
             type: string
         - in: path
-          name: user_id
+          name: id
           required: true
           schema:
             type: string

--- a/internal/ai/langchain/provider.go
+++ b/internal/ai/langchain/provider.go
@@ -330,7 +330,7 @@ func (p *LangchainProvider) MaxTokensPerBatch() int {
 			return 16000 // DeepSeek chat/reasoner models
 		case "openrouter":
 			return 8000 // OpenRouter models commonly cap around 8k; stay conservative
-		case "anthropic":
+		case "anthropic", "anthropic-compatible":
 			return 20000 // Claude models
 		default:
 			return 8000 // Conservative default for unknown providers
@@ -372,7 +372,7 @@ func (p *LangchainProvider) initializeLLM() error {
 	case "openrouter":
 		p.baseURL = aiconnectors.ResolveBaseURLForProviderName(p.providerType, p.baseURL)
 		return p.initializeOpenAILLM()
-	case "anthropic", "claude":
+	case "anthropic", "claude", "anthropic-compatible":
 		return p.initializeAnthropicLLM()
 	default:
 		// Logger accessed via p.logger
@@ -589,8 +589,11 @@ func (p *LangchainProvider) initializeAnthropicLLM() error {
 		anthropic.WithModel(modelName),
 		anthropic.WithHTTPClient(httpClient),
 	}
+	if p.baseURL != "" {
+		options = append(options, anthropic.WithBaseURL(p.baseURL))
+	}
 
-	fmt.Printf("[LANGCHAIN INIT] Initializing Anthropic LLM with model: %s\n", modelName)
+	fmt.Printf("[LANGCHAIN INIT] Initializing Anthropic LLM with model: %s, base URL: %s\n", modelName, p.baseURL)
 
 	llm, err := anthropic.New(options...)
 	if err != nil {
@@ -843,13 +846,16 @@ func (p *LangchainProvider) reviewCodeBatchFormatted(ctx context.Context, diffs 
 		}
 	}()
 
-	// Determine if we should force non-streaming mode for Ollama (useful behind proxies)
-	forceNonStreaming := strings.EqualFold(p.providerType, "ollama") && strings.EqualFold(os.Getenv("LIVEREVIEW_OLLAMA_FORCE_NON_STREAMING"), "true")
+	// Determine if we should force non-streaming mode
+	// Ollama: opt-in via env var (useful behind proxies)
+	// anthropic-compatible: always non-streaming (ClaudeAPI SSE delivers 0 chunks via langchaingo streaming path)
+	forceNonStreaming := (strings.EqualFold(p.providerType, "ollama") && strings.EqualFold(os.Getenv("LIVEREVIEW_OLLAMA_FORCE_NON_STREAMING"), "true")) ||
+		strings.EqualFold(p.providerType, "anthropic-compatible")
 
 	startTime := time.Now()
 	effectiveTemp := p.effectiveTemperature()
 	if forceNonStreaming {
-		fmt.Printf("[STREAM DISABLED] Forcing non-streaming mode for Ollama due to env override.\n")
+		fmt.Printf("[STREAM DISABLED] Forcing non-streaming mode for %s.\n", p.providerType)
 		// Run a single non-streaming request under the same timeout
 		// Progress ticker to show waiting updates while the request is in flight
 		waitingDone := make(chan struct{})
@@ -862,25 +868,44 @@ func (p *LangchainProvider) reviewCodeBatchFormatted(ctx context.Context, diffs 
 					return
 				case <-ticker.C:
 					waited := time.Since(startTime)
-					fmt.Printf("[WAIT] Still waiting for Ollama response... elapsed=%v\n", waited)
+					fmt.Printf("[WAIT] Still waiting for %s response... elapsed=%v\n", p.providerType, waited)
 					if p.logger != nil {
-						p.logger.Log("Waiting for Ollama response... elapsed=%v (non-streaming)", waited)
+						p.logger.Log("Waiting for %s response... elapsed=%v (non-streaming)", p.providerType, waited)
 					}
 				}
 			}
 		}()
-		out, callErr := llms.GenerateFromSinglePrompt(
+		maxTok := p.maxTokens
+		if maxTok <= 0 {
+			// For anthropic-compatible (e.g. ClaudeAPI), extended thinking is enabled by default
+			// and consumes tokens from the max_tokens budget. Opus models need more headroom.
+			if strings.EqualFold(p.providerType, "anthropic-compatible") {
+				maxTok = 16000
+			} else {
+				maxTok = 8000
+			}
+		}
+		genResp, callErr := p.llm.GenerateContent(
 			timeoutCtx,
-			p.llm,
-			prompt,
+			[]llms.MessageContent{{
+				Role:  llms.ChatMessageTypeHuman,
+				Parts: []llms.ContentPart{llms.TextContent{Text: prompt}},
+			}},
 			llms.WithTemperature(effectiveTemp),
+			llms.WithMaxTokens(maxTok),
 		)
 		close(waitingDone)
 		if callErr != nil {
 			err = callErr
 		} else {
-			responseBuilder.WriteString(out)
-			// simulate chunk count for logging
+			// Find first non-empty text choice — thinking blocks appear as choices with Content=""
+			// and the actual text follows as a later choice.
+			for _, choice := range genResp.Choices {
+				if choice.Content != "" {
+					responseBuilder.WriteString(choice.Content)
+					break
+				}
+			}
 			totalChunks = 1
 		}
 	} else {

--- a/internal/ai/langchain/provider.go
+++ b/internal/ai/langchain/provider.go
@@ -608,6 +608,78 @@ func (p *LangchainProvider) getModelName() string {
 	return p.modelName
 }
 
+// callAnthropicDirect makes a direct non-streaming POST to the Anthropic messages API.
+// Used for anthropic-compatible providers (e.g. ClaudeAPI) to avoid langchaingo's internal
+// streaming path, which hangs for models that don't use extended thinking (e.g. haiku).
+func (p *LangchainProvider) callAnthropicDirect(ctx context.Context, prompt string, maxTokens int, temperature float64) (string, error) {
+	baseURL := p.baseURL
+	if baseURL == "" {
+		baseURL = "https://api.anthropic.com/v1"
+	}
+
+	modelName := p.getModelName()
+
+	type message struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	reqPayload := map[string]interface{}{
+		"model":      modelName,
+		"max_tokens": maxTokens,
+		"messages":   []message{{Role: "user", Content: prompt}},
+	}
+	// opus-4 models don't accept a temperature parameter
+	if !strings.Contains(strings.ToLower(modelName), "opus-4") {
+		reqPayload["temperature"] = temperature
+	}
+
+	bodyBytes, err := json.Marshal(reqPayload)
+	if err != nil {
+		return "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/messages", bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("x-api-key", p.apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("content-type", "application/json")
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("http call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API error %d: %s", resp.StatusCode, truncateString(string(respBytes), 500))
+	}
+
+	var result struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		StopReason string `json:"stop_reason"`
+	}
+	if err := json.Unmarshal(respBytes, &result); err != nil {
+		return "", fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	for _, block := range result.Content {
+		if block.Type == "text" && block.Text != "" {
+			return block.Text, nil
+		}
+	}
+	return "", fmt.Errorf("no text block in response (stop_reason=%s, blocks=%d)", result.StopReason, len(result.Content))
+}
+
 func (p *LangchainProvider) getLoggedModelName() string {
 	if p.providerName == aidefault.ProviderName {
 		return aidefault.ProviderName
@@ -856,8 +928,6 @@ func (p *LangchainProvider) reviewCodeBatchFormatted(ctx context.Context, diffs 
 	effectiveTemp := p.effectiveTemperature()
 	if forceNonStreaming {
 		fmt.Printf("[STREAM DISABLED] Forcing non-streaming mode for %s.\n", p.providerType)
-		// Run a single non-streaming request under the same timeout
-		// Progress ticker to show waiting updates while the request is in flight
 		waitingDone := make(chan struct{})
 		go func() {
 			ticker := time.NewTicker(10 * time.Second)
@@ -877,37 +947,41 @@ func (p *LangchainProvider) reviewCodeBatchFormatted(ctx context.Context, diffs 
 		}()
 		maxTok := p.maxTokens
 		if maxTok <= 0 {
-			// For anthropic-compatible (e.g. ClaudeAPI), extended thinking is enabled by default
-			// and consumes tokens from the max_tokens budget. Opus models need more headroom.
+			// anthropic-compatible: extended thinking on sonnet/opus consumes token budget;
+			// use 16000 to leave headroom for the actual text response.
 			if strings.EqualFold(p.providerType, "anthropic-compatible") {
 				maxTok = 16000
 			} else {
 				maxTok = 8000
 			}
 		}
-		genResp, callErr := p.llm.GenerateContent(
-			timeoutCtx,
-			[]llms.MessageContent{{
-				Role:  llms.ChatMessageTypeHuman,
-				Parts: []llms.ContentPart{llms.TextContent{Text: prompt}},
-			}},
-			llms.WithTemperature(effectiveTemp),
-			llms.WithMaxTokens(maxTok),
-		)
+
+		var callErr error
+		if strings.EqualFold(p.providerType, "anthropic-compatible") {
+			// Use direct HTTP POST (stream:false) to avoid langchaingo's internal streaming,
+			// which hangs for models without extended thinking (e.g. haiku) on ClaudeAPI.
+			var text string
+			text, callErr = p.callAnthropicDirect(timeoutCtx, prompt, maxTok, effectiveTemp)
+			if callErr == nil {
+				responseBuilder.WriteString(text)
+			}
+		} else {
+			var out string
+			out, callErr = llms.GenerateFromSinglePrompt(
+				timeoutCtx,
+				p.llm,
+				prompt,
+				llms.WithTemperature(effectiveTemp),
+			)
+			if callErr == nil {
+				responseBuilder.WriteString(out)
+			}
+		}
 		close(waitingDone)
 		if callErr != nil {
 			err = callErr
-		} else {
-			// Find first non-empty text choice — thinking blocks appear as choices with Content=""
-			// and the actual text follows as a later choice.
-			for _, choice := range genResp.Choices {
-				if choice.Content != "" {
-					responseBuilder.WriteString(choice.Content)
-					break
-				}
-			}
-			totalChunks = 1
 		}
+		totalChunks = 1
 	} else {
 		// DEBUGGING: Save the exact prompt to a file for curl testing
 		promptFile := fmt.Sprintf("/tmp/livereview_prompt_%s.txt", batchId)

--- a/internal/aiconnectors/connector.go
+++ b/internal/aiconnectors/connector.go
@@ -27,14 +27,15 @@ type Provider string
 
 const (
 	// Provider types
-	ProviderOpenAI     Provider = "openai"
-	ProviderDeepSeek   Provider = "deepseek"
-	ProviderGemini     Provider = "gemini"
-	ProviderClaude     Provider = "claude"
-	ProviderCohere     Provider = "cohere"
-	ProviderOllama     Provider = "ollama"
-	ProviderOpenRouter Provider = "openrouter"
-	ProviderLocalModel Provider = "local"
+	ProviderOpenAI              Provider = "openai"
+	ProviderDeepSeek            Provider = "deepseek"
+	ProviderGemini              Provider = "gemini"
+	ProviderClaude              Provider = "claude"
+	ProviderAnthropicCompatible Provider = "anthropic-compatible"
+	ProviderCohere              Provider = "cohere"
+	ProviderOllama              Provider = "ollama"
+	ProviderOpenRouter          Provider = "openrouter"
+	ProviderLocalModel          Provider = "local"
 )
 
 // ModelConfig contains the configuration for a specific model
@@ -79,7 +80,7 @@ func NewConnector(ctx context.Context, options ConnectorOptions) (*Connector, er
 		model, err = createDeepSeekModel(ctx, options)
 	case ProviderGemini:
 		model, err = createGeminiModel(ctx, options)
-	case ProviderClaude:
+	case ProviderClaude, ProviderAnthropicCompatible:
 		model, err = createAnthropicModel(ctx, options)
 	case ProviderCohere:
 		model, err = createCohereModel(ctx, options)
@@ -395,6 +396,9 @@ func createAnthropicModel(ctx context.Context, options ConnectorOptions) (llms.M
 		anthropic.WithModel(modelName),
 		anthropic.WithHTTPClient(httpClient),
 	}
+	if options.BaseURL != "" {
+		opts = append(opts, anthropic.WithBaseURL(options.BaseURL))
+	}
 
 	return anthropic.New(opts...)
 }
@@ -542,7 +546,7 @@ func (c *Connector) Call(ctx context.Context, input string, options ...llms.Call
 
 func isCloudProviderProvider(provider Provider) bool {
 	switch provider {
-	case ProviderOpenAI, ProviderDeepSeek, ProviderGemini, ProviderClaude, ProviderOpenRouter:
+	case ProviderOpenAI, ProviderDeepSeek, ProviderGemini, ProviderClaude, ProviderAnthropicCompatible, ProviderOpenRouter:
 		return true
 	default:
 		return false

--- a/internal/aiconnectors/storage.go
+++ b/internal/aiconnectors/storage.go
@@ -345,6 +345,9 @@ func (s *Storage) GetDefaultModel(ctx context.Context, provider Provider) string
 	if provider == ProviderOllama {
 		return "llama3"
 	}
+	if provider == ProviderAnthropicCompatible {
+		provider = ProviderClaude
+	}
 
 	if s.db == nil {
 		return ""


### PR DESCRIPTION
Adds `anthropic-compatible` as a first-class provider type that routes
to the Anthropic langchaingo path with a configurable base URL. This
enables third-party Claude-compatible endpoints (e.g. gw.claudeapi.com)
as connectors without touching the existing claude provider.

Key changes:
- New ProviderAnthropicCompatible constant; wired through connector
  creation, cloud provider classification, and default model lookup
- Direct non-streaming HTTP path for review calls — bypasses
  langchaingo's internal streaming which hangs on models without
  extended thinking and returns empty for models that use it
- Handles extended thinking responses (thinking block + text block)
  by finding the first text-type block in the response
- max_tokens defaulted to 16000 for this provider to leave headroom
  when extended thinking consumes part of the token budget