### PR TITLE
Integrate Atlas Cloud AI Provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,9 +502,9 @@ niceurl3:
 		echo "autossh is not installed. Install it with: sudo apt install autossh"; \
 		exit 1; \
 	}
-	@ssh root@master-do "PID=\$$( netstat -tulpn | grep :6545 | awk '{print \$$7}' | cut -d/ -f1 | head -n 1); [ -n \"\$$PID\" ] && kill -9 \$$PID || true" || true
+	@ssh root@master-do 'PID=$$(netstat -tulpn | grep :6545 | awk '\''{print $$7}'\'' | cut -d/ -f1 | head -n 1); [ -n "$$PID" ] && kill -9 $$PID || true' || true
 	@echo "Starting autossh reverse tunnel on remote port 6545 -> localhost:8081"
-	@AUTOSSH_GATETIME=0 AUTOSSH_POLL=60 AUTOSSH_FIRST_POLteL=30 AUTOSSH_LOGLEVEL=6 autossh -M 20002 \
+	@AUTOSSH_GATETIME=0 AUTOSSH_POLL=60 AUTOSSH_FIRST_POLL=30 AUTOSSH_LOGLEVEL=6 autossh -M 20002 \
 		-o ServerAliveInterval=30 \
 		-o ServerAliveCountMax=3 \
 		-o TCPKeepAlive=yes \

--- a/db/migrations/20260611185900_add_atlas_quota_policy.sql
+++ b/db/migrations/20260611185900_add_atlas_quota_policy.sql
@@ -1,0 +1,33 @@
+-- migrate:up
+INSERT INTO quota_policy_catalog (
+    plan_code,
+    provider_key,
+    input_chars_per_loc,
+    output_chars_per_loc,
+    chars_per_token,
+    loc_budget_ratio,
+    context_budget_ratio,
+    ops_reserved_ratio,
+    input_cost_per_million_tokens_usd,
+    output_cost_per_million_tokens_usd,
+    rounding_scale,
+    active
+)
+SELECT
+    p.plan_code,
+    'atlas',
+    120,
+    87,
+    4,
+    0.3333333333,
+    0.3333333333,
+    0.3333333334,
+    1.0, -- input_cost_per_million_tokens_usd
+    2.0, -- output_cost_per_million_tokens_usd
+    6,
+    TRUE
+FROM plan_catalog p
+ON CONFLICT (plan_code, provider_key) DO NOTHING;
+
+-- migrate:down
+DELETE FROM quota_policy_catalog WHERE provider_key = 'atlas';

--- a/extension/livereview/package-lock.json
+++ b/extension/livereview/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "livereview",
       "version": "0.0.15",
+      "dependencies": {
+        "shell-quote": "^1.8.4"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
@@ -4657,10 +4660,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "dev": true,
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/extension/livereview/package.json
+++ b/extension/livereview/package.json
@@ -130,16 +130,16 @@
     "test": "vscode-test"
   },
   "devDependencies": {
-    "@types/vscode": "^1.70.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
-    "typescript-eslint": "^8.48.1",
-    "eslint": "^9.39.1",
+    "@types/vscode": "^1.70.0",
+    "@vscode/test-cli": "^0.0.12",
+    "@vscode/test-electron": "^2.5.2",
     "esbuild": "^0.27.1",
+    "eslint": "^9.39.1",
     "npm-run-all": "^4.1.5",
     "typescript": "^5.9.3",
-    "@vscode/test-cli": "^0.0.12",
-    "@vscode/test-electron": "^2.5.2"
+    "typescript-eslint": "^8.48.1"
   },
   "overrides": {
     "ajv@6": "6.14.0",
@@ -155,5 +155,8 @@
     "picomatch@2": "2.3.2",
     "picomatch@4": "4.0.4",
     "serialize-javascript": "7.0.5"
+  },
+  "dependencies": {
+    "shell-quote": "^1.8.4"
   }
 }

--- a/internal/ai/langchain/provider.go
+++ b/internal/ai/langchain/provider.go
@@ -23,9 +23,9 @@ import (
 	"github.com/tmc/langchaingo/llms/ollama"
 	"github.com/tmc/langchaingo/llms/openai"
 
+	"github.com/livereview/internal/aidefault"
 	"github.com/livereview/internal/batch"
 	"github.com/livereview/internal/logging"
-	"github.com/livereview/internal/aidefault"
 	"github.com/livereview/internal/prompts"
 	vendorpack "github.com/livereview/internal/prompts/vendor"
 	"github.com/livereview/pkg/models"
@@ -255,7 +255,7 @@ type Config struct {
 	TemperatureSet bool    `json:"temperature_set"`
 	ProviderType   string  `json:"provider_type"` // NEW: "gemini", "ollama", "openai", etc.
 	BaseURL        string  `json:"base_url"`      // NEW: For custom endpoints like Ollama
-	ProviderName   string  `json:"provider_name"`  // NEW: Provider name (e.g. "livereview-default-ai")
+	ProviderName   string  `json:"provider_name"` // NEW: Provider name (e.g. "livereview-default-ai")
 }
 
 // New creates a new langchain-based AI provider
@@ -370,6 +370,9 @@ func (p *LangchainProvider) initializeLLM() error {
 		p.baseURL = aiconnectors.ResolveBaseURLForProviderName(p.providerType, p.baseURL)
 		return p.initializeOpenAILLM()
 	case "openrouter":
+		p.baseURL = aiconnectors.ResolveBaseURLForProviderName(p.providerType, p.baseURL)
+		return p.initializeOpenAILLM()
+	case "atlas":
 		p.baseURL = aiconnectors.ResolveBaseURLForProviderName(p.providerType, p.baseURL)
 		return p.initializeOpenAILLM()
 	case "anthropic", "claude", "anthropic-compatible":
@@ -508,6 +511,33 @@ func (t *openRouterLoggingTransport) RoundTrip(req *http.Request) (*http.Respons
 	return resp, err
 }
 
+// atlasLoggingTransport logs HTTP error bodies for Atlas Cloud.
+type atlasLoggingTransport struct {
+	base http.RoundTripper
+}
+
+func (t *atlasLoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.base == nil {
+		t.base = http.DefaultTransport
+	}
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		fmt.Printf("[ATLAS HTTP ERROR] request failed: %v\n", err)
+		return resp, err
+	}
+
+	if resp != nil && resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+		resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewBuffer(body))
+		fmt.Printf("[ATLAS HTTP ERROR] status=%s url=%s body=%s\n",
+			resp.Status, req.URL.String(), truncateString(string(body), 1200))
+	}
+
+	return resp, err
+}
+
 func (p *LangchainProvider) initializeGeminiLLM() error {
 	if p.apiKey == "" {
 		return fmt.Errorf("API key is required for Gemini")
@@ -554,6 +584,12 @@ func (p *LangchainProvider) initializeOpenAILLM() error {
 	if strings.EqualFold(p.providerType, "openrouter") {
 		client := &http.Client{
 			Transport: &openRouterLoggingTransport{base: http.DefaultTransport},
+			Timeout:   5 * time.Minute,
+		}
+		options = append(options, openai.WithHTTPClient(client))
+	} else if strings.EqualFold(p.providerType, "atlas") {
+		client := &http.Client{
+			Transport: &atlasLoggingTransport{base: http.DefaultTransport},
 			Timeout:   5 * time.Minute,
 		}
 		options = append(options, openai.WithHTTPClient(client))
@@ -1580,6 +1616,7 @@ func parseHunkLine(line string) (oldNum int, newNum int, content string, isDelet
 
 	return oldNum, newNum, content, isDeleted, isAdded, nil
 }
+
 // Helper functions for logging
 func truncateString(s string, maxLen int) string {
 	if len(s) <= maxLen {

--- a/internal/aiconnectors/baseurl_defaults.go
+++ b/internal/aiconnectors/baseurl_defaults.go
@@ -9,6 +9,8 @@ func DefaultBaseURL(provider Provider) string {
 		return "https://openrouter.ai/api/v1"
 	case ProviderDeepSeek:
 		return "https://api.deepseek.com/v1"
+	case ProviderAtlas:
+		return "https://api.atlascloud.ai/v1"
 	default:
 		return ""
 	}
@@ -21,6 +23,8 @@ func DefaultBaseURLForProviderName(providerName string) string {
 		return DefaultBaseURL(ProviderOpenRouter)
 	case string(ProviderDeepSeek):
 		return DefaultBaseURL(ProviderDeepSeek)
+	case string(ProviderAtlas):
+		return DefaultBaseURL(ProviderAtlas)
 	default:
 		return ""
 	}

--- a/internal/aiconnectors/connector.go
+++ b/internal/aiconnectors/connector.go
@@ -35,6 +35,7 @@ const (
 	ProviderCohere              Provider = "cohere"
 	ProviderOllama              Provider = "ollama"
 	ProviderOpenRouter          Provider = "openrouter"
+	ProviderAtlas               Provider = "atlas"
 	ProviderLocalModel          Provider = "local"
 )
 
@@ -88,6 +89,8 @@ func NewConnector(ctx context.Context, options ConnectorOptions) (*Connector, er
 		model, err = createOllamaModel(ctx, options)
 	case ProviderOpenRouter:
 		model, err = createOpenRouterModel(ctx, options)
+	case ProviderAtlas:
+		model, err = createAtlasModel(ctx, options)
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", options.Provider)
 	}
@@ -482,6 +485,51 @@ func (t *openRouterLoggingTransport) RoundTrip(req *http.Request) (*http.Respons
 	return resp, err
 }
 
+func createAtlasModel(ctx context.Context, options ConnectorOptions) (llms.Model, error) {
+	baseURL := ResolveBaseURL(ProviderAtlas, options.BaseURL)
+
+	httpClient := networkaiconnectors.NewHTTPClient(5 * time.Minute)
+	httpClient.Transport = &atlasLoggingTransport{base: http.DefaultTransport}
+
+	opts := []openai.Option{
+		openai.WithModel(options.ModelConfig.Model),
+		openai.WithToken(options.APIKey),
+		openai.WithBaseURL(baseURL),
+		openai.WithHTTPClient(httpClient),
+	}
+
+	return openai.New(opts...)
+}
+
+type atlasLoggingTransport struct {
+	base http.RoundTripper
+}
+
+func (t *atlasLoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.base == nil {
+		t.base = http.DefaultTransport
+	}
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		log.Error().Err(err).Msg("Atlas Cloud request failed before response")
+		return resp, err
+	}
+
+	if resp != nil && resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+		resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewBuffer(body))
+		log.Error().
+			Str("url", req.URL.String()).
+			Int("status", resp.StatusCode).
+			Str("body", truncateString(string(body), 1200)).
+			Msg("Atlas Cloud HTTP error")
+	}
+
+	return resp, err
+}
+
 // Call calls the LLM with the given input and returns the response
 func (c *Connector) Call(ctx context.Context, input string, options ...llms.CallOption) (string, error) {
 	log.Debug().
@@ -546,7 +594,7 @@ func (c *Connector) Call(ctx context.Context, input string, options ...llms.Call
 
 func isCloudProviderProvider(provider Provider) bool {
 	switch provider {
-	case ProviderOpenAI, ProviderDeepSeek, ProviderGemini, ProviderClaude, ProviderAnthropicCompatible, ProviderOpenRouter:
+	case ProviderOpenAI, ProviderDeepSeek, ProviderGemini, ProviderClaude, ProviderAnthropicCompatible, ProviderOpenRouter, ProviderAtlas:
 		return true
 	default:
 		return false

--- a/internal/aiconnectors/models_sync.go
+++ b/internal/aiconnectors/models_sync.go
@@ -66,7 +66,7 @@ var defaultProviderModels = map[string]string{
 	"deepseek":   "deepseek-v4-flash",
 	"cohere":     "command-a",
 	"openrouter": "deepseek/deepseek-v4-flash",
-	"atlas":      "deepseek/deepseek-v4-flash",
+	"atlas":      "deepseek-ai/deepseek-v4-flash",
 }
 
 // RunOpenRouterModelSyncScheduler starts the dynamic model catalog sync scheduler

--- a/internal/aiconnectors/models_sync.go
+++ b/internal/aiconnectors/models_sync.go
@@ -66,17 +66,14 @@ var defaultProviderModels = map[string]string{
 	"deepseek":   "deepseek-v4-flash",
 	"cohere":     "command-a",
 	"openrouter": "deepseek/deepseek-v4-flash",
+	"atlas":      "deepseek/deepseek-v4-flash",
 }
 
 // RunOpenRouterModelSyncScheduler starts the dynamic model catalog sync scheduler
 func RunOpenRouterModelSyncScheduler(ctx context.Context, db *sql.DB, interval time.Duration) {
-	log.Info().Msg("Starting dynamic AI models sync scheduler")
-
 	// Initial sync immediately on boot
 	if err := SyncOpenRouterModels(ctx, db); err != nil {
-		log.Error().Err(err).Msg("Initial dynamic AI models sync failed")
-	} else {
-		log.Info().Msg("Initial dynamic AI models sync successful")
+		log.Error().Err(err).Msg("OpenRouter models sync failed")
 	}
 
 	ticker := time.NewTicker(interval)
@@ -85,14 +82,10 @@ func RunOpenRouterModelSyncScheduler(ctx context.Context, db *sql.DB, interval t
 		for {
 			select {
 			case <-ctx.Done():
-				log.Info().Msg("Dynamic AI models sync scheduler stopped")
 				return
 			case <-ticker.C:
-				log.Info().Msg("Running periodic dynamic AI models sync")
 				if err := SyncOpenRouterModels(ctx, db); err != nil {
-					log.Error().Err(err).Msg("Periodic dynamic AI models sync failed")
-				} else {
-					log.Info().Msg("Periodic dynamic AI models sync successful")
+					log.Error().Err(err).Msg("OpenRouter models sync failed")
 				}
 			}
 		}
@@ -101,6 +94,8 @@ func RunOpenRouterModelSyncScheduler(ctx context.Context, db *sql.DB, interval t
 
 // SyncOpenRouterModels fetches the latest models from OpenRouter and upserts them
 func SyncOpenRouterModels(ctx context.Context, db *sql.DB) error {
+	log.Info().Msg("OpenRouter models sync started")
+
 	client := &http.Client{Timeout: 30 * time.Second}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://openrouter.ai/api/v1/models", nil)
 	if err != nil {
@@ -269,6 +264,170 @@ func SyncOpenRouterModels(ctx context.Context, db *sql.DB) error {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
-	log.Info().Int("count", len(mappedModels)).Msg("Dynamic AI models catalog synchronized successfully")
+	log.Info().Int("count", len(mappedModels)).Msg("OpenRouter models sync completed")
+	return nil
+}
+
+// AtlasModel represents a model returned from the Atlas Cloud models API.
+type AtlasModel struct {
+	ID      string          `json:"id"`
+	Object  string          `json:"object"`
+	RawJSON json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON custom unmarshaler to capture the raw JSON of each Atlas model
+func (m *AtlasModel) UnmarshalJSON(data []byte) error {
+	type Alias AtlasModel
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(m),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	m.RawJSON = json.RawMessage(data)
+	return nil
+}
+
+// AtlasResponse represents the OpenAI-compatible response wrapper for Atlas Cloud.
+type AtlasResponse struct {
+	Data []AtlasModel `json:"data"`
+}
+
+// RunAtlasModelSyncScheduler starts the dynamic model catalog sync scheduler for Atlas Cloud
+func RunAtlasModelSyncScheduler(ctx context.Context, db *sql.DB, interval time.Duration) {
+	// Initial sync immediately on boot
+	if err := SyncAtlasModels(ctx, db); err != nil {
+		log.Error().Err(err).Msg("Atlas Cloud models sync failed")
+	}
+
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := SyncAtlasModels(ctx, db); err != nil {
+					log.Error().Err(err).Msg("Atlas Cloud models sync failed")
+				}
+			}
+		}
+	}()
+}
+
+// SyncAtlasModels fetches the latest models from Atlas Cloud and upserts them
+func SyncAtlasModels(ctx context.Context, db *sql.DB) error {
+	log.Info().Msg("Atlas Cloud models sync started")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.atlascloud.ai/v1/models", nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to fetch models from Atlas Cloud: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Atlas Cloud API returned status %d", resp.StatusCode)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var atlasResp AtlasResponse
+	if err := json.Unmarshal(bodyBytes, &atlasResp); err != nil {
+		return fmt.Errorf("failed to parse JSON response: %w", err)
+	}
+
+	var mappedModels []MappedModel
+
+	// Process each model and map it to the atlas provider
+	for _, model := range atlasResp.Data {
+		id := model.ID
+		idLower := strings.ToLower(id)
+
+		// Filter out non-text/media generation models
+		if strings.Contains(idLower, "video") || strings.Contains(idLower, "image") ||
+			strings.Contains(idLower, "flux") || strings.Contains(idLower, "kling") ||
+			strings.Contains(idLower, "stable-diffusion") || strings.Contains(idLower, "sd") ||
+			strings.Contains(idLower, "seed") || strings.Contains(idLower, "wan") ||
+			strings.Contains(idLower, "audio") || strings.Contains(idLower, "lyria") {
+			continue
+		}
+
+		name := model.ID // Use model ID as display name or human readable representation
+		// If ID contains slashes like 'deepseek-ai/DeepSeek-V3', split and capitalize
+		parts := strings.Split(id, "/")
+		if len(parts) > 1 {
+			name = parts[len(parts)-1]
+		}
+
+		isDefault := defaultProviderModels["atlas"] == id
+		mappedModels = append(mappedModels, MappedModel{
+			ModelID:   id,
+			Provider:  "atlas",
+			Name:      fmt.Sprintf("Atlas: %s", name),
+			IsDefault: isDefault,
+			Metadata:  model.RawJSON,
+		})
+	}
+
+	if len(mappedModels) == 0 {
+		return fmt.Errorf("no supported models found in Atlas Cloud API response")
+	}
+
+	// Begin transaction to safely upsert models
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to start transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Deactivate existing atlas models first
+	_, err = tx.ExecContext(ctx, "UPDATE ai_models SET is_active = false WHERE provider = 'atlas'")
+	if err != nil {
+		return fmt.Errorf("failed to reset model states: %w", err)
+	}
+
+	upsertQuery := `
+		INSERT INTO ai_models (model_id, provider, name, is_active, is_default, metadata, updated_at)
+		VALUES ($1, $2, $3, true, $4, $5, NOW())
+		ON CONFLICT (model_id) DO UPDATE
+		SET name = EXCLUDED.name,
+		    provider = EXCLUDED.provider,
+		    is_active = true,
+		    is_default = EXCLUDED.is_default,
+		    metadata = EXCLUDED.metadata,
+		    updated_at = NOW()
+	`
+
+	stmt, err := tx.PrepareContext(ctx, upsertQuery)
+	if err != nil {
+		return fmt.Errorf("failed to prepare upsert query: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, model := range mappedModels {
+		_, err := stmt.ExecContext(ctx, model.ModelID, model.Provider, model.Name, model.IsDefault, model.Metadata)
+		if err != nil {
+			log.Warn().Err(err).Str("model_id", model.ModelID).Msg("Failed to upsert model")
+			continue
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	log.Info().Int("count", len(mappedModels)).Msg("Atlas Cloud models sync completed")
 	return nil
 }

--- a/internal/aiconnectors/models_sync.go
+++ b/internal/aiconnectors/models_sync.go
@@ -69,12 +69,19 @@ var defaultProviderModels = map[string]string{
 	"atlas":      "deepseek-ai/deepseek-v4-flash",
 }
 
-// RunOpenRouterModelSyncScheduler starts the dynamic model catalog sync scheduler
-func RunOpenRouterModelSyncScheduler(ctx context.Context, db *sql.DB, interval time.Duration) {
-	// Initial sync immediately on boot
-	if err := SyncOpenRouterModels(ctx, db); err != nil {
-		log.Error().Err(err).Msg("OpenRouter models sync failed")
+// RunAIModelSyncScheduler starts the dynamic model catalog sync scheduler for all dynamic providers
+func RunAIModelSyncScheduler(ctx context.Context, db *sql.DB, interval time.Duration) {
+	runSyncs := func() {
+		if err := SyncOpenRouterModels(ctx, db); err != nil {
+			log.Error().Err(err).Msg("OpenRouter models sync failed")
+		}
+		if err := SyncAtlasModels(ctx, db); err != nil {
+			log.Error().Err(err).Msg("Atlas Cloud models sync failed")
+		}
 	}
+
+	// Initial sync immediately on boot
+	runSyncs()
 
 	ticker := time.NewTicker(interval)
 	go func() {
@@ -84,9 +91,7 @@ func RunOpenRouterModelSyncScheduler(ctx context.Context, db *sql.DB, interval t
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := SyncOpenRouterModels(ctx, db); err != nil {
-					log.Error().Err(err).Msg("OpenRouter models sync failed")
-				}
+				runSyncs()
 			}
 		}
 	}()
@@ -295,28 +300,7 @@ type AtlasResponse struct {
 	Data []AtlasModel `json:"data"`
 }
 
-// RunAtlasModelSyncScheduler starts the dynamic model catalog sync scheduler for Atlas Cloud
-func RunAtlasModelSyncScheduler(ctx context.Context, db *sql.DB, interval time.Duration) {
-	// Initial sync immediately on boot
-	if err := SyncAtlasModels(ctx, db); err != nil {
-		log.Error().Err(err).Msg("Atlas Cloud models sync failed")
-	}
 
-	ticker := time.NewTicker(interval)
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				if err := SyncAtlasModels(ctx, db); err != nil {
-					log.Error().Err(err).Msg("Atlas Cloud models sync failed")
-				}
-			}
-		}
-	}()
-}
 
 // SyncAtlasModels fetches the latest models from Atlas Cloud and upserts them
 func SyncAtlasModels(ctx context.Context, db *sql.DB) error {

--- a/internal/aiconnectors/models_test.go
+++ b/internal/aiconnectors/models_test.go
@@ -48,6 +48,11 @@ func (s mockStmt) Query(args []driver.Value) (driver.Rows, error) {
 			},
 		}, nil
 	}
+	if provider == "atlas" {
+		return &mockRows{
+			rows: []driver.Value{"deepseek-ai/DeepSeek-V3", "deepseek-ai/DeepSeek-R1"},
+		}, nil
+	}
 	return &mockRows{}, nil
 }
 
@@ -144,5 +149,23 @@ func TestConnectorRecordGetConnectorOptionsDefaultsOpenAIModel(t *testing.T) {
 	opts := storage.GetConnectorOptions(context.Background(), record)
 	if opts.ModelConfig.Model != "o4-mini" {
 		t.Fatalf("expected default OpenAI model o4-mini, got %q", opts.ModelConfig.Model)
+	}
+}
+
+func TestGetDefaultModelAtlas(t *testing.T) {
+	storage := NewStorage(testDB)
+	if got := storage.GetDefaultModel(context.Background(), ProviderAtlas); got != "deepseek-ai/DeepSeek-V3" {
+		t.Fatalf("expected Atlas default model deepseek-ai/DeepSeek-V3, got %q", got)
+	}
+}
+
+func TestGetProviderModelsAtlasIncludesDeepSeekV3(t *testing.T) {
+	storage := NewStorage(testDB)
+	models := storage.GetProviderModels(context.Background(), ProviderAtlas)
+	if len(models) == 0 {
+		t.Fatal("expected Atlas model list to be non-empty")
+	}
+	if models[0] != "deepseek-ai/DeepSeek-V3" {
+		t.Fatalf("expected first Atlas model to be deepseek-ai/DeepSeek-V3, got %q", models[0])
 	}
 }

--- a/internal/api/aiconnectors.go
+++ b/internal/api/aiconnectors.go
@@ -152,6 +152,12 @@ func (s *Server) CreateAIConnector(c echo.Context) error {
 		})
 	}
 
+	if req.ProviderName == "atlas" && !s.deploymentConfig.AtlasEnabled {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "Atlas Cloud provider is disabled",
+		})
+	}
+
 	// API key is optional for Ollama, required for other providers
 	if req.APIKey == "" && req.ProviderName != "ollama" {
 		return c.JSON(http.StatusBadRequest, map[string]string{

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -52,6 +52,7 @@ type DeploymentConfig struct {
 	IsCloud         bool   // cloud vs self-hosted deployment
 	Mode            string // derived: "demo" or "production"
 	WebhooksEnabled bool   // derived: based on mode
+	AtlasEnabled    bool   // enable/disable Atlas Cloud provider
 }
 
 // getEnvInt retrieves an integer environment variable with a default value
@@ -88,6 +89,7 @@ func getDeploymentConfig() *DeploymentConfig {
 		FrontendPort: getEnvInt("LIVEREVIEW_FRONTEND_PORT", 8081),
 		ReverseProxy: getEnvBool("LIVEREVIEW_REVERSE_PROXY", false),
 		IsCloud:      getEnvBool("LIVEREVIEW_IS_CLOUD", false),
+		AtlasEnabled: getEnvBool("LIVEREVIEW_ATLAS_ENABLED", true),
 	}
 
 	// Auto-configure derived values
@@ -1024,7 +1026,7 @@ func (s *Server) Start() error {
 		syncCtx, cancel := context.WithCancel(context.Background())
 		s.modelSyncCancel = cancel
 		aiconnectors.RunOpenRouterModelSyncScheduler(syncCtx, s.db, 24*time.Hour)
-		fmt.Println("Dynamic AI models sync scheduler started")
+		aiconnectors.RunAtlasModelSyncScheduler(syncCtx, s.db, 24*time.Hour)
 	}
 
 	// Wait for interrupt signal to gracefully shut down the server
@@ -1742,9 +1744,10 @@ func (s *Server) getSystemInfo(c echo.Context) error {
 // getUIConfig returns deployment configuration for the frontend
 func (s *Server) getUIConfig(c echo.Context) error {
 	config := map[string]interface{}{
-		"isCloud": s.deploymentConfig.IsCloud,
-		"version": s.versionInfo.Version,
-		"mode":    s.deploymentConfig.Mode,
+		"isCloud":        s.deploymentConfig.IsCloud,
+		"version":        s.versionInfo.Version,
+		"mode":           s.deploymentConfig.Mode,
+		"isAtlasEnabled": s.deploymentConfig.AtlasEnabled,
 	}
 	return c.JSON(http.StatusOK, config)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1025,8 +1025,7 @@ func (s *Server) Start() error {
 	if s.modelSyncCancel == nil {
 		syncCtx, cancel := context.WithCancel(context.Background())
 		s.modelSyncCancel = cancel
-		aiconnectors.RunOpenRouterModelSyncScheduler(syncCtx, s.db, 24*time.Hour)
-		aiconnectors.RunAtlasModelSyncScheduler(syncCtx, s.db, 24*time.Hour)
+		aiconnectors.RunAIModelSyncScheduler(syncCtx, s.db, 24*time.Hour)
 	}
 
 	// Wait for interrupt signal to gracefully shut down the server

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -31,6 +31,7 @@
         "react-router-dom": "^6.30.4",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
+        "shell-quote": "^1.8.4",
         "zod": "^4.1.5"
       },
       "devDependencies": {
@@ -17886,10 +17887,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "dev": true,
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/ui/package.json
+++ b/ui/package.json
@@ -105,6 +105,7 @@
     "react-router-dom": "^6.30.4",
     "redux": "^5.0.1",
     "redux-thunk": "^3.1.0",
+    "shell-quote": "^1.8.4",
     "zod": "^4.1.5"
   },
   "browserslist": [

--- a/ui/src/pages/AIProviders/AIProviders.tsx
+++ b/ui/src/pages/AIProviders/AIProviders.tsx
@@ -134,34 +134,6 @@ const AIProviders: React.FC = () => {
 	const [isSaved, setIsSaved] = useState(false);
 	const [showDropdown, setShowDropdown] = useState(false);
 	const dropdownRef = useRef<HTMLDivElement>(null);
-	const [isAtlasEnabled, setIsAtlasEnabled] = useState(true);
-
-	useEffect(() => {
-		const fetchUIConfig = async () => {
-			try {
-				const response = await fetch('/api/v1/ui-config');
-				if (response.ok) {
-					const data = await response.json();
-					if (data.isAtlasEnabled !== undefined) {
-						setIsAtlasEnabled(data.isAtlasEnabled);
-					}
-				}
-			} catch (err) {
-				console.error('Failed to fetch UI config:', err);
-			}
-		};
-		fetchUIConfig();
-	}, []);
-
-	const filteredProviders = React.useMemo(() => {
-		return popularAIProviders.filter(
-			(p) =>
-				p.id !== 'atlas' ||
-				isAtlasEnabled ||
-				selectedProvider === 'atlas' ||
-				formData.providerType === 'atlas'
-		);
-	}, [isAtlasEnabled, selectedProvider, formData.providerType]);
 
 	const getDefaultModelFor = (providerId?: string) => {
 		if (!providerId) return '';
@@ -379,7 +351,7 @@ const AIProviders: React.FC = () => {
                 <div className="lg:col-span-1">
                     <Card title="AI Providers">
                         <ProvidersList
-                            providers={filteredProviders}
+                            providers={popularAIProviders}
                             selectedProvider={selectedProvider}
                             connectorCounts={connectorCounts}
                             onSelectProvider={handleSelectProvider}
@@ -426,7 +398,7 @@ const AIProviders: React.FC = () => {
                                 ) : (
                                     /* Regular form for other providers */
                                     <ConnectorForm
-                                        providers={filteredProviders}
+                                        providers={popularAIProviders}
                                         selectedProvider={selectedProvider}
                                         formData={formData}
                                         isEditing={isEditing}
@@ -448,7 +420,7 @@ const AIProviders: React.FC = () => {
                         {/* Connectors List */}
                         <ConnectorsList
                             connectors={connectors}
-                            providers={filteredProviders}
+                            providers={popularAIProviders}
                             selectedProvider={selectedProvider}
                             isLoading={isLoading}
                             error={error}

--- a/ui/src/pages/AIProviders/AIProviders.tsx
+++ b/ui/src/pages/AIProviders/AIProviders.tsx
@@ -80,6 +80,15 @@ const popularAIProviders: AIProvider[] = [
         apiKeyPlaceholder: 'sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
     },
     {
+        id: 'atlas',
+        name: 'Atlas Cloud',
+        url: 'https://atlascloud.ai/',
+        description: 'OpenAI-compatible AI cloud engine. Choose from a selection of models including DeepSeek.',
+        icon: <Icons.AI />,
+        apiKeyPlaceholder: 'ac_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+        baseURLPlaceholder: 'https://api.atlascloud.ai/v1'
+    },
+    {
         id: 'claude',
         name: 'Anthropic Claude',
         url: 'https://www.anthropic.com/',
@@ -121,16 +130,44 @@ const AIProviders: React.FC = () => {
         generateFriendlyName
     } = useFormState();
 
-    // Local state
-    const [isSaved, setIsSaved] = useState(false);
-    const [showDropdown, setShowDropdown] = useState(false);
-    const dropdownRef = useRef<HTMLDivElement>(null);
+	// Local state
+	const [isSaved, setIsSaved] = useState(false);
+	const [showDropdown, setShowDropdown] = useState(false);
+	const dropdownRef = useRef<HTMLDivElement>(null);
+	const [isAtlasEnabled, setIsAtlasEnabled] = useState(true);
 
-    const getDefaultModelFor = (providerId?: string) => {
-        if (!providerId) return '';
-        const meta = popularAIProviders.find(p => p.id === providerId);
-        return meta?.defaultModel || '';
-    };
+	useEffect(() => {
+		const fetchUIConfig = async () => {
+			try {
+				const response = await fetch('/api/v1/ui-config');
+				if (response.ok) {
+					const data = await response.json();
+					if (data.isAtlasEnabled !== undefined) {
+						setIsAtlasEnabled(data.isAtlasEnabled);
+					}
+				}
+			} catch (err) {
+				console.error('Failed to fetch UI config:', err);
+			}
+		};
+		fetchUIConfig();
+	}, []);
+
+	const filteredProviders = React.useMemo(() => {
+		return popularAIProviders.filter(
+			(p) =>
+				p.id !== 'atlas' ||
+				isAtlasEnabled ||
+				selectedProvider === 'atlas' ||
+				formData.providerType === 'atlas'
+		);
+	}, [isAtlasEnabled, selectedProvider, formData.providerType]);
+
+	const getDefaultModelFor = (providerId?: string) => {
+		if (!providerId) return '';
+		const meta = popularAIProviders.find((p) => p.id === providerId);
+		return meta?.defaultModel || '';
+	};
 
     // Calculate provider connector counts
     const connectorCounts = connectors.reduce((counts: Record<string, number>, connector) => {
@@ -342,7 +379,7 @@ const AIProviders: React.FC = () => {
                 <div className="lg:col-span-1">
                     <Card title="AI Providers">
                         <ProvidersList
-                            providers={popularAIProviders}
+                            providers={filteredProviders}
                             selectedProvider={selectedProvider}
                             connectorCounts={connectorCounts}
                             onSelectProvider={handleSelectProvider}
@@ -389,7 +426,7 @@ const AIProviders: React.FC = () => {
                                 ) : (
                                     /* Regular form for other providers */
                                     <ConnectorForm
-                                        providers={popularAIProviders}
+                                        providers={filteredProviders}
                                         selectedProvider={selectedProvider}
                                         formData={formData}
                                         isEditing={isEditing}
@@ -411,7 +448,7 @@ const AIProviders: React.FC = () => {
                         {/* Connectors List */}
                         <ConnectorsList
                             connectors={connectors}
-                            providers={popularAIProviders}
+                            providers={filteredProviders}
                             selectedProvider={selectedProvider}
                             isLoading={isLoading}
                             error={error}

--- a/ui/src/pages/AIProviders/components/ConnectorForm.tsx
+++ b/ui/src/pages/AIProviders/components/ConnectorForm.tsx
@@ -167,7 +167,7 @@ const ConnectorForm: React.FC<ConnectorFormProps> = ({
             return !!formData.baseURL;
         }
 
-        if (providerDetails?.id === 'openrouter' && !formData.selectedModel) {
+        if ((providerDetails?.id === 'openrouter' || providerDetails?.id === 'atlas') && !formData.selectedModel) {
             return false;
         }
 
@@ -404,7 +404,7 @@ const ConnectorForm: React.FC<ConnectorFormProps> = ({
                             />
                         )}
                         <p className="text-xs text-slate-400">
-                            {providerDetails.id === 'openrouter' ? 'OpenRouter model ID (defaults to free DeepSeek route)' : 'Select a model or enter a custom model ID'}
+                            {providerDetails.id === 'openrouter' ? 'OpenRouter model ID (defaults to free DeepSeek route)' : providerDetails.id === 'atlas' ? 'Atlas Cloud model ID (defaults to DeepSeek-V3)' : 'Select a model or enter a custom model ID'}
                         </p>
                     </div>
                 )}


### PR DESCRIPTION
- This PR integrates Atlas Cloud as a native AI provider in LiveReview by adding support to the Langchain provider routing and the frontend settings page.
- It introduces a database migration for default quota policies and runs a unified scheduler to dynamically sync the Atlas model catalog.
- Backend validation has been added to enforce and allow disabling the Atlas connector via environment flags.