### PR TITLE
Standardize SMTP configuration and refactor email handling

### DIFF
--- a/db/migrations/20260623135113_create_system_settings_table.sql
+++ b/db/migrations/20260623135113_create_system_settings_table.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+
+
+-- migrate:down
+

--- a/db/migrations/20260623135113_create_system_settings_table.sql
+++ b/db/migrations/20260623135113_create_system_settings_table.sql
@@ -1,5 +1,10 @@
 -- migrate:up
-
+CREATE TABLE system_settings (
+	name VARCHAR(255) PRIMARY KEY,
+	data JSONB NOT NULL,
+	created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+	updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
 
 -- migrate:down
-
+DROP TABLE IF EXISTS system_settings;

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -672,6 +672,11 @@ func (s *Server) setupRoutes() {
 	adminGroup.PUT("/users/:user_id/org", s.userHandlers.TransferUserToOrg)
 	adminGroup.GET("/analytics/users", s.userHandlers.GetUserAnalytics)
 
+	// Super admin SMTP settings endpoints
+	adminGroup.GET("/settings/smtp", s.GetSMTPSettings)
+	adminGroup.PUT("/settings/smtp", s.UpdateSMTPSettings)
+	adminGroup.POST("/settings/smtp/test", s.TestSMTPSettings)
+
 	// Organization management endpoints
 	// User organization access (get their orgs) - needs permission context to detect super admin
 	protectedOrgsGroup := protected.Group("")

--- a/internal/api/system_settings.go
+++ b/internal/api/system_settings.go
@@ -6,19 +6,13 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/livereview/internal/api/auth"
+	"github.com/livereview/pkg/models"
 	"github.com/livereview/network/email"
 	"github.com/rs/zerolog/log"
 )
 
-type SMTPSettings struct {
-	Host       string `json:"host"`
-	Port       int    `json:"port"`
-	Username   string `json:"username"`
-	Password   string `json:"password"`
-	Sender     string `json:"sender"`
-	SenderName string `json:"sender_name"`
-	SkipTLS    bool   `json:"skip_tls"`
-}
+
 
 // GetSMTPSettings fetches the global SMTP configuration from system_settings
 func (s *Server) GetSMTPSettings(c echo.Context) error {
@@ -27,16 +21,16 @@ func (s *Server) GetSMTPSettings(c echo.Context) error {
 	if err != nil {
 		if err == sql.ErrNoRows {
 			// Return empty settings if not configured
-			return c.JSON(http.StatusOK, SMTPSettings{})
+			return c.JSON(http.StatusOK, models.SMTPSettings{})
 		}
 		log.Error().Err(err).Msg("Failed to fetch SMTP settings")
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to fetch SMTP settings"})
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to fetch SMTP settings: " + err.Error()})
 	}
 
-	var settings SMTPSettings
+	var settings models.SMTPSettings
 	if err := json.Unmarshal(data, &settings); err != nil {
 		log.Error().Err(err).Msg("Failed to parse SMTP settings")
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to parse SMTP settings"})
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to parse SMTP settings: " + err.Error()})
 	}
 
 	return c.JSON(http.StatusOK, settings)
@@ -44,9 +38,19 @@ func (s *Server) GetSMTPSettings(c echo.Context) error {
 
 // UpdateSMTPSettings saves the global SMTP configuration to system_settings
 func (s *Server) UpdateSMTPSettings(c echo.Context) error {
-	var settings SMTPSettings
+	var settings models.SMTPSettings
 	if err := c.Bind(&settings); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request payload"})
+	}
+
+	if settings.Host == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "SMTP Host is required"})
+	}
+	if settings.Port <= 0 || settings.Port > 65535 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid SMTP Port"})
+	}
+	if settings.Sender == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Sender email is required"})
 	}
 
 	data, err := json.Marshal(settings)
@@ -63,7 +67,7 @@ func (s *Server) UpdateSMTPSettings(c echo.Context) error {
 	
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to save SMTP settings")
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to save SMTP settings"})
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to save SMTP settings: " + err.Error()})
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "SMTP settings updated successfully"})
@@ -71,19 +75,34 @@ func (s *Server) UpdateSMTPSettings(c echo.Context) error {
 
 // TestSMTPSettings attempts to send a test email using the provided credentials
 func (s *Server) TestSMTPSettings(c echo.Context) error {
-	var settings SMTPSettings
+	var settings models.SMTPSettings
 	if err := c.Bind(&settings); err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request payload"})
 	}
 
-	// Make sure we have an email to send to
-	userEmail := c.Get("email").(string)
-	if userEmail == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Could not determine admin email for test"})
+	if settings.Host == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "SMTP Host is required"})
+	}
+	if settings.Port <= 0 || settings.Port > 65535 {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid SMTP Port"})
+	}
+	if settings.Sender == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Sender email is required"})
 	}
 
+	// Make sure we have an email to send to
+	userInterface := c.Get(string(auth.UserContextKey))
+	if userInterface == nil {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Unauthorized"})
+	}
+	user, ok := userInterface.(*models.User)
+	if !ok || user == nil || user.Email == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Could not determine admin email for test"})
+	}
+	userEmail := user.Email
+
 	// Create a test message
-	err := email.SendTestEmailSMTP(
+	err := email.SendVerificationEmailSMTP(
 		settings.Host,
 		settings.Port,
 		settings.Username,
@@ -96,7 +115,7 @@ func (s *Server) TestSMTPSettings(c echo.Context) error {
 
 	if err != nil {
 		log.Error().Err(err).Msg("SMTP Test failed")
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "SMTP Connection Failed: " + err.Error()})
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "SMTP Connection Failed. Check logs for details."})
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "Test email sent successfully to " + userEmail})

--- a/internal/api/system_settings.go
+++ b/internal/api/system_settings.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/livereview/network/email"
+	"github.com/rs/zerolog/log"
+)
+
+type SMTPSettings struct {
+	Host       string `json:"host"`
+	Port       int    `json:"port"`
+	Username   string `json:"username"`
+	Password   string `json:"password"`
+	Sender     string `json:"sender"`
+	SenderName string `json:"sender_name"`
+	SkipTLS    bool   `json:"skip_tls"`
+}
+
+// GetSMTPSettings fetches the global SMTP configuration from system_settings
+func (s *Server) GetSMTPSettings(c echo.Context) error {
+	var data []byte
+	err := s.db.QueryRow("SELECT data FROM system_settings WHERE name = 'smtp'").Scan(&data)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			// Return empty settings if not configured
+			return c.JSON(http.StatusOK, SMTPSettings{})
+		}
+		log.Error().Err(err).Msg("Failed to fetch SMTP settings")
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to fetch SMTP settings"})
+	}
+
+	var settings SMTPSettings
+	if err := json.Unmarshal(data, &settings); err != nil {
+		log.Error().Err(err).Msg("Failed to parse SMTP settings")
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to parse SMTP settings"})
+	}
+
+	return c.JSON(http.StatusOK, settings)
+}
+
+// UpdateSMTPSettings saves the global SMTP configuration to system_settings
+func (s *Server) UpdateSMTPSettings(c echo.Context) error {
+	var settings SMTPSettings
+	if err := c.Bind(&settings); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request payload"})
+	}
+
+	data, err := json.Marshal(settings)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to marshal SMTP settings")
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to process settings"})
+	}
+
+	_, err = s.db.Exec(`
+		INSERT INTO system_settings (name, data) 
+		VALUES ('smtp', $1)
+		ON CONFLICT (name) DO UPDATE SET data = EXCLUDED.data, updated_at = CURRENT_TIMESTAMP
+	`, data)
+	
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to save SMTP settings")
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to save SMTP settings"})
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"message": "SMTP settings updated successfully"})
+}
+
+// TestSMTPSettings attempts to send a test email using the provided credentials
+func (s *Server) TestSMTPSettings(c echo.Context) error {
+	var settings SMTPSettings
+	if err := c.Bind(&settings); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request payload"})
+	}
+
+	// Make sure we have an email to send to
+	userEmail := c.Get("email").(string)
+	if userEmail == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Could not determine admin email for test"})
+	}
+
+	// Create a test message
+	err := email.SendTestEmailSMTP(
+		settings.Host,
+		settings.Port,
+		settings.Username,
+		settings.Password,
+		settings.Sender,
+		settings.SenderName,
+		settings.SkipTLS,
+		userEmail,
+	)
+
+	if err != nil {
+		log.Error().Err(err).Msg("SMTP Test failed")
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "SMTP Connection Failed: " + err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, map[string]string{"message": "Test email sent successfully to " + userEmail})
+}

--- a/internal/api/system_settings.go
+++ b/internal/api/system_settings.go
@@ -3,6 +3,7 @@ package api
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -13,6 +14,18 @@ import (
 )
 
 
+func validateSMTPSettings(settings models.SMTPSettings) error {
+	if settings.Host == "" {
+		return errors.New("SMTP Host is required")
+	}
+	if settings.Port <= 0 || settings.Port > 65535 {
+		return errors.New("Invalid SMTP Port")
+	}
+	if settings.Sender == "" {
+		return errors.New("Sender email is required")
+	}
+	return nil
+}
 
 // GetSMTPSettings fetches the global SMTP configuration from system_settings
 func (s *Server) GetSMTPSettings(c echo.Context) error {
@@ -24,13 +37,13 @@ func (s *Server) GetSMTPSettings(c echo.Context) error {
 			return c.JSON(http.StatusOK, models.SMTPSettings{})
 		}
 		log.Error().Err(err).Msg("Failed to fetch SMTP settings")
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to fetch SMTP settings: " + err.Error()})
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to fetch SMTP settings"})
 	}
 
 	var settings models.SMTPSettings
 	if err := json.Unmarshal(data, &settings); err != nil {
 		log.Error().Err(err).Msg("Failed to parse SMTP settings")
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to parse SMTP settings: " + err.Error()})
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to parse SMTP settings"})
 	}
 
 	return c.JSON(http.StatusOK, settings)
@@ -43,14 +56,8 @@ func (s *Server) UpdateSMTPSettings(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request payload"})
 	}
 
-	if settings.Host == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "SMTP Host is required"})
-	}
-	if settings.Port <= 0 || settings.Port > 65535 {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid SMTP Port"})
-	}
-	if settings.Sender == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Sender email is required"})
+	if err := validateSMTPSettings(settings); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 
 	data, err := json.Marshal(settings)
@@ -67,7 +74,7 @@ func (s *Server) UpdateSMTPSettings(c echo.Context) error {
 	
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to save SMTP settings")
-		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to save SMTP settings: " + err.Error()})
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to save SMTP settings"})
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"message": "SMTP settings updated successfully"})
@@ -80,14 +87,8 @@ func (s *Server) TestSMTPSettings(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid request payload"})
 	}
 
-	if settings.Host == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "SMTP Host is required"})
-	}
-	if settings.Port <= 0 || settings.Port > 65535 {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid SMTP Port"})
-	}
-	if settings.Sender == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "Sender email is required"})
+	if err := validateSMTPSettings(settings); err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
 	}
 
 	// Make sure we have an email to send to

--- a/internal/api/users/user_service.go
+++ b/internal/api/users/user_service.go
@@ -20,6 +20,7 @@ type APIKeyGeneratorTx func(tx *sql.Tx, userID, orgID int64) (string, error)
 
 // UserService handles core user management operations
 type UserService struct {
+	db              *sql.DB
 	store           *storageusers.UserStore
 	apiKeyGenerator APIKeyGeneratorTx
 }
@@ -27,6 +28,7 @@ type UserService struct {
 // NewUserService creates a new user service
 func NewUserService(db *sql.DB, apiKeyGenerator APIKeyGeneratorTx) *UserService {
 	return &UserService{
+		db:              db,
 		store:           storageusers.NewUserStore(db),
 		apiKeyGenerator: apiKeyGenerator,
 	}
@@ -197,7 +199,7 @@ func (us *UserService) sendInvitation(user *UserWithRole, invitedByUserID int64)
 		installCmdWindows = fmt.Sprintf("$env:LRC_API_KEY=%q; $env:LRC_API_URL=%q; iwr -useb https://hexmos.com/lrc-install.ps1 | iex", user.OnboardingAPIKey, defaultProductionURL)
 	}
 
-	err := email.SendInvitationEmail(email.InvitationParams{
+	err := email.SendInvitationEmail(us.db, email.InvitationParams{
 		AppName:               "LiveReview",
 		InvitedToName:         invitedToName,
 		InvitedToEmail:        user.Email,

--- a/network/email/invitation.go
+++ b/network/email/invitation.go
@@ -2,11 +2,13 @@ package email
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -27,11 +29,45 @@ func getParseAppID() string {
 	return "impressionserver"
 }
 
-// SendInvitationEmail sends an invitation email via the Parse Cloud Function
-func SendInvitationEmail(params InvitationParams) error {
+// SendInvitationEmail sends an invitation email. It uses SMTP for self-hosted/enterprise deployments
+func SendInvitationEmail(db *sql.DB, params InvitationParams) error {
+	isCloud := strings.ToLower(os.Getenv("LIVEREVIEW_IS_CLOUD")) == "true"
+	if !isCloud {
+		// First try fetching from database system_settings
+		var data []byte
+		
+		err := db.QueryRow("SELECT data FROM system_settings WHERE name = 'smtp'").Scan(&data)
+		if err == nil {
+			var settings struct {
+				Host       string `json:"host"`
+				Port       int    `json:"port"`
+				Username   string `json:"username"`
+				Password   string `json:"password"`
+				Sender     string `json:"sender"`
+				SenderName string `json:"sender_name"`
+				SkipTLS    bool   `json:"skip_tls"`
+			}
+			if err := json.Unmarshal(data, &settings); err == nil && settings.Host != "" {
+				return SendInvitationEmailSMTP(
+					settings.Host,
+					settings.Port,
+					settings.Username,
+					settings.Password,
+					settings.Sender,
+					settings.SenderName,
+					settings.SkipTLS,
+					params,
+				)
+			}
+		}
+
+		fmt.Println("[Invitation] Selfhosted/Enterprise mode: SMTP settings not found in database, skipping invitation email")
+		return nil
+	}
+
 	baseURL := os.Getenv("FW_PARSE_BASE_URL")
 	if baseURL == "" {
-		fmt.Println("[Invitation] FW_PARSE_BASE_URL not set, skipping invitation");
+		fmt.Println("[Invitation] Cloud mode: FW_PARSE_BASE_URL not set, skipping invitation")
 		return nil
 	}
 	apiURL := fmt.Sprintf("%s/parse/functions/userInvitation", baseURL)

--- a/network/email/invitation.go
+++ b/network/email/invitation.go
@@ -10,6 +10,9 @@ import (
 	"os"
 	"strings"
 	"time"
+	
+	"github.com/rs/zerolog/log"
+	"github.com/livereview/pkg/models"
 )
 
 type InvitationParams struct {
@@ -37,17 +40,13 @@ func SendInvitationEmail(db *sql.DB, params InvitationParams) error {
 		var data []byte
 		
 		err := db.QueryRow("SELECT data FROM system_settings WHERE name = 'smtp'").Scan(&data)
-		if err == nil {
-			var settings struct {
-				Host       string `json:"host"`
-				Port       int    `json:"port"`
-				Username   string `json:"username"`
-				Password   string `json:"password"`
-				Sender     string `json:"sender"`
-				SenderName string `json:"sender_name"`
-				SkipTLS    bool   `json:"skip_tls"`
-			}
-			if err := json.Unmarshal(data, &settings); err == nil && settings.Host != "" {
+		if err != nil && err != sql.ErrNoRows {
+			log.Error().Err(err).Msg("Database error when fetching SMTP settings")
+		} else if err == nil {
+			var settings models.SMTPSettings
+			if err := json.Unmarshal(data, &settings); err != nil {
+				log.Error().Err(err).Msg("Failed to unmarshal SMTP settings")
+			} else if settings.Host != "" {
 				return SendInvitationEmailSMTP(
 					settings.Host,
 					settings.Port,
@@ -61,20 +60,20 @@ func SendInvitationEmail(db *sql.DB, params InvitationParams) error {
 			}
 		}
 
-		fmt.Println("[Invitation] Selfhosted/Enterprise mode: SMTP settings not found in database, skipping invitation email")
+		log.Info().Msg("[Invitation] Selfhosted/Enterprise mode: SMTP settings not found in database, skipping invitation email")
 		return nil
 	}
 
 	baseURL := os.Getenv("FW_PARSE_BASE_URL")
 	if baseURL == "" {
-		fmt.Println("[Invitation] Cloud mode: FW_PARSE_BASE_URL not set, skipping invitation")
+		log.Info().Msg("[Invitation] Cloud mode: FW_PARSE_BASE_URL not set, skipping invitation")
 		return nil
 	}
 	apiURL := fmt.Sprintf("%s/parse/functions/userInvitation", baseURL)
 
 	appID := getParseAppID()
 
-	fmt.Printf("[Invitation] Calling Parse invitation API at: %s for %s\n", apiURL, params.InvitedToEmail)
+	log.Info().Msgf("[Invitation] Calling Parse invitation API at: %s for %s", apiURL, params.InvitedToEmail)
 
 	jsonData, err := json.Marshal(params)
 	if err != nil {

--- a/network/email/smtp.go
+++ b/network/email/smtp.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/tls"
 	"fmt"
 	"html/template"
@@ -10,186 +11,15 @@ import (
 	"strings"
 	textTemplate "text/template"
 	"time"
+	_ "embed"
+	"github.com/rs/zerolog/log"
 )
 
-const invitationHTMLTemplate = `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Join {{.AppName}}</title>
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-      background-color: #f3f4f6;
-      margin: 0;
-      padding: 0;
-      -webkit-font-smoothing: antialiased;
-    }
-    .wrapper {
-      width: 100%;
-      background-color: #f3f4f6;
-      padding: 40px 20px;
-      box-sizing: border-box;
-    }
-    .container {
-      max-width: 600px;
-      margin: 0 auto;
-      background: #ffffff;
-      border-radius: 16px;
-      overflow: hidden;
-      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
-    }
-    .header {
-      background: linear-gradient(135deg, #013E7D 0%, #002244 100%);
-      padding: 40px;
-      text-align: center;
-      color: #ffffff;
-    }
-    .header h1 {
-      margin: 0;
-      font-size: 28px;
-      font-weight: 700;
-      letter-spacing: -0.5px;
-    }
-    .content {
-      padding: 40px;
-      color: #374151;
-      line-height: 1.6;
-    }
-    .greeting {
-      font-size: 18px;
-      font-weight: 600;
-      margin-bottom: 16px;
-    }
-    .message {
-      font-size: 16px;
-      margin-bottom: 24px;
-    }
-    .cta-container {
-      text-align: center;
-      margin: 32px 0;
-    }
-    .btn {
-      display: inline-block;
-      padding: 14px 30px;
-      background-color: #013E7D;
-      color: #ffffff !important;
-      text-decoration: none;
-      border-radius: 8px;
-      font-weight: 600;
-      font-size: 16px;
-      box-shadow: 0 4px 12px rgba(1, 62, 125, 0.2);
-    }
-    .btn:hover {
-      background-color: #002c5c;
-    }
-    .cli-section {
-      background-color: #0f172a;
-      border-radius: 12px;
-      padding: 24px;
-      color: #f8fafc;
-      margin-top: 32px;
-    }
-    .cli-title {
-      font-size: 14px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 1px;
-      color: #94a3b8;
-      margin-bottom: 16px;
-    }
-    .cli-header {
-      font-size: 13px;
-      color: #38bdf8;
-      margin-bottom: 6px;
-      font-weight: 600;
-    }
-    .code-block {
-      background-color: #1e293b;
-      padding: 12px;
-      border-radius: 6px;
-      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
-      font-size: 13px;
-      margin: 0 0 16px 0;
-      white-space: pre-wrap;
-      word-break: break-all;
-      color: #e2e8f0;
-      border-left: 4px solid #38bdf8;
-    }
-    .code-block:last-child {
-      margin-bottom: 0;
-    }
-    .footer {
-      background-color: #f9fafb;
-      padding: 24px 40px;
-      text-align: center;
-      font-size: 12px;
-      color: #9ca3af;
-      border-top: 1px solid #f3f4f6;
-    }
-  </style>
-</head>
-<body>
-  <div class="wrapper">
-    <div class="container">
-      <div class="header">
-        <h1>LiveReview</h1>
-      </div>
-      <div class="content">
-        <div class="greeting">Hi {{.InvitedToName}},</div>
-        <div class="message">
-          <strong>{{.InvitedByName}}</strong> has invited you to join the <strong>{{.AppName}}</strong> workspace. Collaborative, AI-powered code reviews are just one step away.
-        </div>
-        <div class="cta-container">
-          <a href="{{.URL}}" class="btn">Join Workspace</a>
-        </div>
-        
-        {{if or .InstallCommandLinux .InstallCommandWindows}}
-        <div class="cli-section">
-          <div class="cli-title">Get Started with the CLI</div>
-          
-          {{if .InstallCommandLinux}}
-          <div class="cli-header">Linux / macOS Install Command:</div>
-          <pre class="code-block">{{.InstallCommandLinux}}</pre>
-          {{end}}
-          
-          {{if .InstallCommandWindows}}
-          <div class="cli-header">Windows PowerShell Install Command:</div>
-          <pre class="code-block">{{.InstallCommandWindows}}</pre>
-          {{end}}
-        </div>
-        {{end}}
-      </div>
-      <div class="footer">
-        This is an automated invitation email. If you did not expect this, you can safely ignore it.<br>
-        &copy; 2026 LiveReview. All rights reserved.
-      </div>
-    </div>
-  </div>
-</body>
-</html>
-`
+//go:embed templates/invitation.html
+var invitationHTMLTemplate string
 
-const invitationTextTemplate = `Hi {{.InvitedToName}},
-
-{{.InvitedByName}} has invited you to join the {{.AppName}} workspace!
-
-Join Workspace:
-{{.URL}}
-{{if or .InstallCommandLinux .InstallCommandWindows}}
-Get Started with the CLI:
-{{if .InstallCommandLinux}}
-Linux / macOS:
-{{.InstallCommandLinux}}
-{{end}}
-{{if .InstallCommandWindows}}
-Windows PowerShell:
-{{.InstallCommandWindows}}
-{{end}}
-{{end}}
-This is an automated invitation email. If you did not expect this, you can safely ignore it.
-`
+//go:embed templates/invitation.txt
+var invitationTextTemplate string
 
 // SendInvitationEmailSMTP sends the invitation email using SMTP credentials
 func SendInvitationEmailSMTP(host string, port int, username, password, sender, senderName string, skipTLS bool, params InvitationParams) error {
@@ -221,7 +51,9 @@ func SendInvitationEmailSMTP(host string, port int, username, password, sender, 
 	}
 
 	// Construct email message with multipart/alternative MIME type
-	boundary := "livereview-smtp-boundary-12345"
+	randBytes := make([]byte, 16)
+	_, _ = rand.Read(randBytes)
+	boundary := fmt.Sprintf("livereview-smtp-boundary-%x", randBytes)
 	subject := fmt.Sprintf("Join %s Workspace", params.AppName)
 
 	header := make(map[string]string)
@@ -259,12 +91,12 @@ func SendInvitationEmailSMTP(host string, port int, username, password, sender, 
 		InsecureSkipVerify: skipTLS,
 	}
 
-	fmt.Printf("[Invitation] Sending SMTP email via %s to %s\n", addr, params.InvitedToEmail)
+	log.Info().Msgf("[Invitation] Sending SMTP email via %s to %s", addr, params.InvitedToEmail)
 
 	var conn net.Conn
 	if port == 465 {
 		// SSL/TLS direct connection
-		conn, err = tls.Dial("tcp", addr, tlsConfig)
+		conn, err = tls.DialWithDialer(&net.Dialer{Timeout: 10 * time.Second}, "tcp", addr, tlsConfig)
 		if err != nil {
 			return fmt.Errorf("failed to dial SMTP over SSL (port 465): %w", err)
 		}
@@ -317,11 +149,12 @@ func SendInvitationEmailSMTP(host string, port int, username, password, sender, 
 		return fmt.Errorf("failed to write SMTP message: %w", err)
 	}
 
-	fmt.Printf("[Invitation] Successfully sent SMTP email to: %s\n", params.InvitedToEmail)
+	log.Info().Msgf("[Invitation] Successfully sent SMTP email to: %s", params.InvitedToEmail)
 	return nil
 }
 
-func SendTestEmailSMTP(host string, port int, username, password, sender, senderName string, skipTLS bool, recipient string) error {
+// SendVerificationEmailSMTP sends a verification email to confirm SMTP settings from the admin dashboard
+func SendVerificationEmailSMTP(host string, port int, username, password, sender, senderName string, skipTLS bool, recipient string) error {
 	params := InvitationParams{
 		AppName:        "LiveReview (Test)",
 		InvitedToName:  "Admin",

--- a/network/email/smtp.go
+++ b/network/email/smtp.go
@@ -1,0 +1,333 @@
+package email
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"html/template"
+	"net"
+	"net/smtp"
+	"strings"
+	textTemplate "text/template"
+	"time"
+)
+
+const invitationHTMLTemplate = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Join {{.AppName}}</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background-color: #f3f4f6;
+      margin: 0;
+      padding: 0;
+      -webkit-font-smoothing: antialiased;
+    }
+    .wrapper {
+      width: 100%;
+      background-color: #f3f4f6;
+      padding: 40px 20px;
+      box-sizing: border-box;
+    }
+    .container {
+      max-width: 600px;
+      margin: 0 auto;
+      background: #ffffff;
+      border-radius: 16px;
+      overflow: hidden;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+    }
+    .header {
+      background: linear-gradient(135deg, #013E7D 0%, #002244 100%);
+      padding: 40px;
+      text-align: center;
+      color: #ffffff;
+    }
+    .header h1 {
+      margin: 0;
+      font-size: 28px;
+      font-weight: 700;
+      letter-spacing: -0.5px;
+    }
+    .content {
+      padding: 40px;
+      color: #374151;
+      line-height: 1.6;
+    }
+    .greeting {
+      font-size: 18px;
+      font-weight: 600;
+      margin-bottom: 16px;
+    }
+    .message {
+      font-size: 16px;
+      margin-bottom: 24px;
+    }
+    .cta-container {
+      text-align: center;
+      margin: 32px 0;
+    }
+    .btn {
+      display: inline-block;
+      padding: 14px 30px;
+      background-color: #013E7D;
+      color: #ffffff !important;
+      text-decoration: none;
+      border-radius: 8px;
+      font-weight: 600;
+      font-size: 16px;
+      box-shadow: 0 4px 12px rgba(1, 62, 125, 0.2);
+    }
+    .btn:hover {
+      background-color: #002c5c;
+    }
+    .cli-section {
+      background-color: #0f172a;
+      border-radius: 12px;
+      padding: 24px;
+      color: #f8fafc;
+      margin-top: 32px;
+    }
+    .cli-title {
+      font-size: 14px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: #94a3b8;
+      margin-bottom: 16px;
+    }
+    .cli-header {
+      font-size: 13px;
+      color: #38bdf8;
+      margin-bottom: 6px;
+      font-weight: 600;
+    }
+    .code-block {
+      background-color: #1e293b;
+      padding: 12px;
+      border-radius: 6px;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+      font-size: 13px;
+      margin: 0 0 16px 0;
+      white-space: pre-wrap;
+      word-break: break-all;
+      color: #e2e8f0;
+      border-left: 4px solid #38bdf8;
+    }
+    .code-block:last-child {
+      margin-bottom: 0;
+    }
+    .footer {
+      background-color: #f9fafb;
+      padding: 24px 40px;
+      text-align: center;
+      font-size: 12px;
+      color: #9ca3af;
+      border-top: 1px solid #f3f4f6;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="container">
+      <div class="header">
+        <h1>LiveReview</h1>
+      </div>
+      <div class="content">
+        <div class="greeting">Hi {{.InvitedToName}},</div>
+        <div class="message">
+          <strong>{{.InvitedByName}}</strong> has invited you to join the <strong>{{.AppName}}</strong> workspace. Collaborative, AI-powered code reviews are just one step away.
+        </div>
+        <div class="cta-container">
+          <a href="{{.URL}}" class="btn">Join Workspace</a>
+        </div>
+        
+        {{if or .InstallCommandLinux .InstallCommandWindows}}
+        <div class="cli-section">
+          <div class="cli-title">Get Started with the CLI</div>
+          
+          {{if .InstallCommandLinux}}
+          <div class="cli-header">Linux / macOS Install Command:</div>
+          <pre class="code-block">{{.InstallCommandLinux}}</pre>
+          {{end}}
+          
+          {{if .InstallCommandWindows}}
+          <div class="cli-header">Windows PowerShell Install Command:</div>
+          <pre class="code-block">{{.InstallCommandWindows}}</pre>
+          {{end}}
+        </div>
+        {{end}}
+      </div>
+      <div class="footer">
+        This is an automated invitation email. If you did not expect this, you can safely ignore it.<br>
+        &copy; 2026 LiveReview. All rights reserved.
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+`
+
+const invitationTextTemplate = `Hi {{.InvitedToName}},
+
+{{.InvitedByName}} has invited you to join the {{.AppName}} workspace!
+
+Join Workspace:
+{{.URL}}
+{{if or .InstallCommandLinux .InstallCommandWindows}}
+Get Started with the CLI:
+{{if .InstallCommandLinux}}
+Linux / macOS:
+{{.InstallCommandLinux}}
+{{end}}
+{{if .InstallCommandWindows}}
+Windows PowerShell:
+{{.InstallCommandWindows}}
+{{end}}
+{{end}}
+This is an automated invitation email. If you did not expect this, you can safely ignore it.
+`
+
+// SendInvitationEmailSMTP sends the invitation email using SMTP credentials
+func SendInvitationEmailSMTP(host string, port int, username, password, sender, senderName string, skipTLS bool, params InvitationParams) error {
+	if host == "" {
+		return fmt.Errorf("SMTP host is not set")
+	}
+
+	if sender == "" {
+		return fmt.Errorf("SMTP sender is not set")
+	}
+
+	// Render templates
+	htmlTmpl, err := template.New("invitationHTML").Parse(invitationHTMLTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse HTML template: %w", err)
+	}
+	var htmlBuf bytes.Buffer
+	if err := htmlTmpl.Execute(&htmlBuf, params); err != nil {
+		return fmt.Errorf("failed to execute HTML template: %w", err)
+	}
+
+	textTmpl, err := textTemplate.New("invitationText").Parse(invitationTextTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse text template: %w", err)
+	}
+	var textBuf bytes.Buffer
+	if err := textTmpl.Execute(&textBuf, params); err != nil {
+		return fmt.Errorf("failed to execute text template: %w", err)
+	}
+
+	// Construct email message with multipart/alternative MIME type
+	boundary := "livereview-smtp-boundary-12345"
+	subject := fmt.Sprintf("Join %s Workspace", params.AppName)
+
+	header := make(map[string]string)
+	header["From"] = fmt.Sprintf("%s <%s>", senderName, sender)
+	header["To"] = params.InvitedToEmail
+	header["Subject"] = subject
+	header["MIME-Version"] = "1.0"
+	header["Content-Type"] = fmt.Sprintf("multipart/alternative; boundary=%s", boundary)
+
+	var message strings.Builder
+	for k, v := range header {
+		message.WriteString(fmt.Sprintf("%s: %s\r\n", k, v))
+	}
+	message.WriteString("\r\n")
+
+	// Plain text boundary section
+	message.WriteString(fmt.Sprintf("--%s\r\n", boundary))
+	message.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n")
+	message.WriteString("Content-Transfer-Encoding: 7bit\r\n\r\n")
+	message.WriteString(textBuf.String())
+	message.WriteString("\r\n\r\n")
+
+	// HTML boundary section
+	message.WriteString(fmt.Sprintf("--%s\r\n", boundary))
+	message.WriteString("Content-Type: text/html; charset=\"utf-8\"\r\n")
+	message.WriteString("Content-Transfer-Encoding: 7bit\r\n\r\n")
+	message.WriteString(htmlBuf.String())
+	message.WriteString("\r\n\r\n")
+
+	message.WriteString(fmt.Sprintf("--%s--\r\n", boundary))
+
+	addr := fmt.Sprintf("%s:%d", host, port)
+	tlsConfig := &tls.Config{
+		ServerName:         host,
+		InsecureSkipVerify: skipTLS,
+	}
+
+	fmt.Printf("[Invitation] Sending SMTP email via %s to %s\n", addr, params.InvitedToEmail)
+
+	var conn net.Conn
+	if port == 465 {
+		// SSL/TLS direct connection
+		conn, err = tls.Dial("tcp", addr, tlsConfig)
+		if err != nil {
+			return fmt.Errorf("failed to dial SMTP over SSL (port 465): %w", err)
+		}
+	} else {
+		// Plain TCP connection with potential STARTTLS
+		conn, err = net.DialTimeout("tcp", addr, 10*time.Second)
+		if err != nil {
+			return fmt.Errorf("failed to dial SMTP server: %w", err)
+		}
+	}
+	defer conn.Close()
+
+	client, err := smtp.NewClient(conn, host)
+	if err != nil {
+		return fmt.Errorf("failed to create SMTP client: %w", err)
+	}
+	defer client.Quit()
+
+	if port != 465 {
+		if hasStartTLS, _ := client.Extension("STARTTLS"); hasStartTLS {
+			if err = client.StartTLS(tlsConfig); err != nil {
+				return fmt.Errorf("failed to start TLS: %w", err)
+			}
+		}
+	}
+
+	if username != "" || password != "" {
+		auth := smtp.PlainAuth("", username, password, host)
+		if err = client.Auth(auth); err != nil {
+			return fmt.Errorf("SMTP authentication failed: %w", err)
+		}
+	}
+
+	if err = client.Mail(sender); err != nil {
+		return fmt.Errorf("failed to set SMTP mail sender: %w", err)
+	}
+
+	if err = client.Rcpt(params.InvitedToEmail); err != nil {
+		return fmt.Errorf("failed to set SMTP mail recipient: %w", err)
+	}
+
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("failed to open SMTP data writer: %w", err)
+	}
+	defer w.Close()
+
+	_, err = w.Write([]byte(message.String()))
+	if err != nil {
+		return fmt.Errorf("failed to write SMTP message: %w", err)
+	}
+
+	fmt.Printf("[Invitation] Successfully sent SMTP email to: %s\n", params.InvitedToEmail)
+	return nil
+}
+
+func SendTestEmailSMTP(host string, port int, username, password, sender, senderName string, skipTLS bool, recipient string) error {
+	params := InvitationParams{
+		AppName:        "LiveReview (Test)",
+		InvitedToName:  "Admin",
+		InvitedToEmail: recipient,
+		InvitedByName:  "System Administrator",
+		URL:            "https://livereview.io",
+	}
+	return SendInvitationEmailSMTP(host, port, username, password, sender, senderName, skipTLS, params)
+}

--- a/network/email/smtp.go
+++ b/network/email/smtp.go
@@ -6,7 +6,9 @@ import (
 	"crypto/tls"
 	"fmt"
 	"html/template"
+	"mime"
 	"net"
+	"net/mail"
 	"net/smtp"
 	"strings"
 	textTemplate "text/template"
@@ -71,15 +73,20 @@ func SendRawEmailSMTP(host string, port int, username, password, sender, senderN
 	boundary := fmt.Sprintf("livereview-smtp-boundary-%x", randBytes)
 
 	header := make(map[string]string)
-	header["From"] = fmt.Sprintf("%s <%s>", senderName, sender)
-	header["To"] = recipient
-	header["Subject"] = subject
+	
+	fromAddr := mail.Address{Name: senderName, Address: sender}
+	header["From"] = fromAddr.String()
+	
+	toAddr := mail.Address{Address: recipient}
+	header["To"] = toAddr.String()
+	
+	header["Subject"] = mime.QEncoding.Encode("utf-8", subject)
 	header["MIME-Version"] = "1.0"
 	header["Content-Type"] = fmt.Sprintf("multipart/alternative; boundary=%s", boundary)
 
 	var message strings.Builder
 	for k, v := range header {
-		// Prevent CRLF injection in email headers
+		// Prevent CRLF injection in any future arbitrary headers (defense in depth)
 		safeV := strings.ReplaceAll(v, "\r", "")
 		safeV = strings.ReplaceAll(safeV, "\n", "")
 		message.WriteString(fmt.Sprintf("%s: %s\r\n", k, safeV))

--- a/network/email/smtp.go
+++ b/network/email/smtp.go
@@ -31,13 +31,22 @@ func SendInvitationEmailSMTP(host string, port int, username, password, sender, 
 		return fmt.Errorf("SMTP sender is not set")
 	}
 
+	// Prepare data for templates
+	data := struct {
+		InvitationParams
+		CurrentYear int
+	}{
+		InvitationParams: params,
+		CurrentYear:      time.Now().Year(),
+	}
+
 	// Render templates
 	htmlTmpl, err := template.New("invitationHTML").Parse(invitationHTMLTemplate)
 	if err != nil {
 		return fmt.Errorf("failed to parse HTML template: %w", err)
 	}
 	var htmlBuf bytes.Buffer
-	if err := htmlTmpl.Execute(&htmlBuf, params); err != nil {
+	if err := htmlTmpl.Execute(&htmlBuf, data); err != nil {
 		return fmt.Errorf("failed to execute HTML template: %w", err)
 	}
 
@@ -46,7 +55,7 @@ func SendInvitationEmailSMTP(host string, port int, username, password, sender, 
 		return fmt.Errorf("failed to parse text template: %w", err)
 	}
 	var textBuf bytes.Buffer
-	if err := textTmpl.Execute(&textBuf, params); err != nil {
+	if err := textTmpl.Execute(&textBuf, data); err != nil {
 		return fmt.Errorf("failed to execute text template: %w", err)
 	}
 

--- a/network/email/smtp.go
+++ b/network/email/smtp.go
@@ -79,7 +79,10 @@ func SendRawEmailSMTP(host string, port int, username, password, sender, senderN
 
 	var message strings.Builder
 	for k, v := range header {
-		message.WriteString(fmt.Sprintf("%s: %s\r\n", k, v))
+		// Prevent CRLF injection in email headers
+		safeV := strings.ReplaceAll(v, "\r", "")
+		safeV = strings.ReplaceAll(safeV, "\n", "")
+		message.WriteString(fmt.Sprintf("%s: %s\r\n", k, safeV))
 	}
 	message.WriteString("\r\n")
 

--- a/network/email/smtp.go
+++ b/network/email/smtp.go
@@ -59,15 +59,20 @@ func SendInvitationEmailSMTP(host string, port int, username, password, sender, 
 		return fmt.Errorf("failed to execute text template: %w", err)
 	}
 
+	subject := fmt.Sprintf("Join %s Workspace", params.AppName)
+	return SendRawEmailSMTP(host, port, username, password, sender, senderName, skipTLS, params.InvitedToEmail, subject, textBuf.String(), htmlBuf.String())
+}
+
+// SendRawEmailSMTP handles the actual SMTP protocol and MIME multipart generation
+func SendRawEmailSMTP(host string, port int, username, password, sender, senderName string, skipTLS bool, recipient, subject, textBody, htmlBody string) error {
 	// Construct email message with multipart/alternative MIME type
 	randBytes := make([]byte, 16)
 	_, _ = rand.Read(randBytes)
 	boundary := fmt.Sprintf("livereview-smtp-boundary-%x", randBytes)
-	subject := fmt.Sprintf("Join %s Workspace", params.AppName)
 
 	header := make(map[string]string)
 	header["From"] = fmt.Sprintf("%s <%s>", senderName, sender)
-	header["To"] = params.InvitedToEmail
+	header["To"] = recipient
 	header["Subject"] = subject
 	header["MIME-Version"] = "1.0"
 	header["Content-Type"] = fmt.Sprintf("multipart/alternative; boundary=%s", boundary)
@@ -82,14 +87,14 @@ func SendInvitationEmailSMTP(host string, port int, username, password, sender, 
 	message.WriteString(fmt.Sprintf("--%s\r\n", boundary))
 	message.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n")
 	message.WriteString("Content-Transfer-Encoding: 7bit\r\n\r\n")
-	message.WriteString(textBuf.String())
+	message.WriteString(textBody)
 	message.WriteString("\r\n\r\n")
 
 	// HTML boundary section
 	message.WriteString(fmt.Sprintf("--%s\r\n", boundary))
 	message.WriteString("Content-Type: text/html; charset=\"utf-8\"\r\n")
 	message.WriteString("Content-Transfer-Encoding: 7bit\r\n\r\n")
-	message.WriteString(htmlBuf.String())
+	message.WriteString(htmlBody)
 	message.WriteString("\r\n\r\n")
 
 	message.WriteString(fmt.Sprintf("--%s--\r\n", boundary))
@@ -100,9 +105,10 @@ func SendInvitationEmailSMTP(host string, port int, username, password, sender, 
 		InsecureSkipVerify: skipTLS,
 	}
 
-	log.Info().Msgf("[Invitation] Sending SMTP email via %s to %s", addr, params.InvitedToEmail)
+	log.Info().Msgf("[SMTP] Sending email via %s to %s", addr, recipient)
 
 	var conn net.Conn
+	var err error
 	if port == 465 {
 		// SSL/TLS direct connection
 		conn, err = tls.DialWithDialer(&net.Dialer{Timeout: 10 * time.Second}, "tcp", addr, tlsConfig)
@@ -143,7 +149,7 @@ func SendInvitationEmailSMTP(host string, port int, username, password, sender, 
 		return fmt.Errorf("failed to set SMTP mail sender: %w", err)
 	}
 
-	if err = client.Rcpt(params.InvitedToEmail); err != nil {
+	if err = client.Rcpt(recipient); err != nil {
 		return fmt.Errorf("failed to set SMTP mail recipient: %w", err)
 	}
 
@@ -158,18 +164,27 @@ func SendInvitationEmailSMTP(host string, port int, username, password, sender, 
 		return fmt.Errorf("failed to write SMTP message: %w", err)
 	}
 
-	log.Info().Msgf("[Invitation] Successfully sent SMTP email to: %s", params.InvitedToEmail)
+	log.Info().Msgf("[SMTP] Successfully sent email to: %s", recipient)
 	return nil
 }
 
 // SendVerificationEmailSMTP sends a verification email to confirm SMTP settings from the admin dashboard
 func SendVerificationEmailSMTP(host string, port int, username, password, sender, senderName string, skipTLS bool, recipient string) error {
-	params := InvitationParams{
-		AppName:        "LiveReview (Test)",
-		InvitedToName:  "Admin",
-		InvitedToEmail: recipient,
-		InvitedByName:  "System Administrator",
-		URL:            "https://livereview.io",
-	}
-	return SendInvitationEmailSMTP(host, port, username, password, sender, senderName, skipTLS, params)
+	subject := "LiveReview SMTP Verification"
+	
+	htmlBody := `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+</head>
+<body style="font-family: sans-serif; padding: 20px;">
+  <h2>SMTP Configuration Successful!</h2>
+  <p>This is a test email from <strong>LiveReview Enterprise version</strong>.</p>
+  <p>Your SMTP configuration has been correctly applied to your self-hosted instance.</p>
+</body>
+</html>`
+
+	textBody := "SMTP Configuration Successful!\n\nThis is a test email from LiveReview Enterprise version.\nYour SMTP configuration has been correctly applied to your self-hosted instance."
+
+	return SendRawEmailSMTP(host, port, username, password, sender, senderName, skipTLS, recipient, subject, textBody, htmlBody)
 }

--- a/network/email/templates/invitation.html
+++ b/network/email/templates/invitation.html
@@ -120,7 +120,7 @@
   <div class="wrapper">
     <div class="container">
       <div class="header">
-        <h1>LiveReview</h1>
+        <h1>{{.AppName}}</h1>
       </div>
       <div class="content">
         <div class="greeting">Hi {{.InvitedToName}},</div>
@@ -149,7 +149,7 @@
       </div>
       <div class="footer">
         This is an automated invitation email. If you did not expect this, you can safely ignore it.<br>
-        &copy; 2026 LiveReview. All rights reserved.
+        &copy; {{.CurrentYear}} {{.AppName}}. All rights reserved.
       </div>
     </div>
   </div>

--- a/network/email/templates/invitation.html
+++ b/network/email/templates/invitation.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Join {{.AppName}}</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background-color: #f3f4f6;
+      margin: 0;
+      padding: 0;
+      -webkit-font-smoothing: antialiased;
+    }
+    .wrapper {
+      width: 100%;
+      background-color: #f3f4f6;
+      padding: 40px 20px;
+      box-sizing: border-box;
+    }
+    .container {
+      max-width: 600px;
+      margin: 0 auto;
+      background: #ffffff;
+      border-radius: 16px;
+      overflow: hidden;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+    }
+    .header {
+      background: linear-gradient(135deg, #013E7D 0%, #002244 100%);
+      padding: 40px;
+      text-align: center;
+      color: #ffffff;
+    }
+    .header h1 {
+      margin: 0;
+      font-size: 28px;
+      font-weight: 700;
+      letter-spacing: -0.5px;
+    }
+    .content {
+      padding: 40px;
+      color: #374151;
+      line-height: 1.6;
+    }
+    .greeting {
+      font-size: 18px;
+      font-weight: 600;
+      margin-bottom: 16px;
+    }
+    .message {
+      font-size: 16px;
+      margin-bottom: 24px;
+    }
+    .cta-container {
+      text-align: center;
+      margin: 32px 0;
+    }
+    .btn {
+      display: inline-block;
+      padding: 14px 30px;
+      background-color: #013E7D;
+      color: #ffffff !important;
+      text-decoration: none;
+      border-radius: 8px;
+      font-weight: 600;
+      font-size: 16px;
+      box-shadow: 0 4px 12px rgba(1, 62, 125, 0.2);
+    }
+    .btn:hover {
+      background-color: #002c5c;
+    }
+    .cli-section {
+      background-color: #0f172a;
+      border-radius: 12px;
+      padding: 24px;
+      color: #f8fafc;
+      margin-top: 32px;
+    }
+    .cli-title {
+      font-size: 14px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      color: #94a3b8;
+      margin-bottom: 16px;
+    }
+    .cli-header {
+      font-size: 13px;
+      color: #38bdf8;
+      margin-bottom: 6px;
+      font-weight: 600;
+    }
+    .code-block {
+      background-color: #1e293b;
+      padding: 12px;
+      border-radius: 6px;
+      font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+      font-size: 13px;
+      margin: 0 0 16px 0;
+      white-space: pre-wrap;
+      word-break: break-all;
+      color: #e2e8f0;
+      border-left: 4px solid #38bdf8;
+    }
+    .code-block:last-child {
+      margin-bottom: 0;
+    }
+    .footer {
+      background-color: #f9fafb;
+      padding: 24px 40px;
+      text-align: center;
+      font-size: 12px;
+      color: #9ca3af;
+      border-top: 1px solid #f3f4f6;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="container">
+      <div class="header">
+        <h1>LiveReview</h1>
+      </div>
+      <div class="content">
+        <div class="greeting">Hi {{.InvitedToName}},</div>
+        <div class="message">
+          <strong>{{.InvitedByName}}</strong> has invited you to join the <strong>{{.AppName}}</strong> workspace. Collaborative, AI-powered code reviews are just one step away.
+        </div>
+        <div class="cta-container">
+          <a href="{{.URL}}" class="btn">Join Workspace</a>
+        </div>
+        
+        {{if or .InstallCommandLinux .InstallCommandWindows}}
+        <div class="cli-section">
+          <div class="cli-title">Get Started with the CLI</div>
+          
+          {{if .InstallCommandLinux}}
+          <div class="cli-header">Linux / macOS Install Command:</div>
+          <pre class="code-block">{{.InstallCommandLinux}}</pre>
+          {{end}}
+          
+          {{if .InstallCommandWindows}}
+          <div class="cli-header">Windows PowerShell Install Command:</div>
+          <pre class="code-block">{{.InstallCommandWindows}}</pre>
+          {{end}}
+        </div>
+        {{end}}
+      </div>
+      <div class="footer">
+        This is an automated invitation email. If you did not expect this, you can safely ignore it.<br>
+        &copy; 2026 LiveReview. All rights reserved.
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/network/email/templates/invitation.txt
+++ b/network/email/templates/invitation.txt
@@ -1,0 +1,18 @@
+Hi {{.InvitedToName}},
+
+{{.InvitedByName}} has invited you to join the {{.AppName}} workspace!
+
+Join Workspace:
+{{.URL}}
+{{if or .InstallCommandLinux .InstallCommandWindows}}
+Get Started with the CLI:
+{{if .InstallCommandLinux}}
+Linux / macOS:
+{{.InstallCommandLinux}}
+{{end}}
+{{if .InstallCommandWindows}}
+Windows PowerShell:
+{{.InstallCommandWindows}}
+{{end}}
+{{end}}
+This is an automated invitation email. If you did not expect this, you can safely ignore it.

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -171,3 +171,13 @@ const (
 	SeverityWarning  CommentSeverity = "warning"
 	SeverityCritical CommentSeverity = "critical"
 )
+
+type SMTPSettings struct {
+	Host       string `json:"host"`
+	Port       int    `json:"port"`
+	Username   string `json:"username"`
+	Password   string `json:"password"`
+	Sender     string `json:"sender"`
+	SenderName string `json:"sender_name"`
+	SkipTLS    bool   `json:"skip_tls"`
+}

--- a/tests/smtp_test.go
+++ b/tests/smtp_test.go
@@ -1,0 +1,154 @@
+package livereview
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/livereview/network/email"
+)
+
+func TestSendInvitationEmailSMTP(t *testing.T) {
+	// Start a local mock SMTP server
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start local mock SMTP server: %v", err)
+	}
+	defer listener.Close()
+
+	_, portStr, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to get port: %v", err)
+	}
+
+	// Set env vars
+	os.Setenv("LIVEREVIEW_IS_CLOUD", "false")
+	os.Setenv("SMTP_HOST", "127.0.0.1")
+	os.Setenv("SMTP_PORT", portStr)
+	os.Setenv("SMTP_USERNAME", "testuser")
+	os.Setenv("SMTP_PASSWORD", "testpass")
+	os.Setenv("SMTP_SENDER", "sender@example.com")
+	os.Setenv("SMTP_SENDER_NAME", "Test Sender")
+	os.Setenv("SMTP_SKIP_TLS", "true") // bypass TLS validation in test
+
+	defer func() {
+		os.Unsetenv("LIVEREVIEW_IS_CLOUD")
+		os.Unsetenv("SMTP_HOST")
+		os.Unsetenv("SMTP_PORT")
+		os.Unsetenv("SMTP_USERNAME")
+		os.Unsetenv("SMTP_PASSWORD")
+		os.Unsetenv("SMTP_SENDER")
+		os.Unsetenv("SMTP_SENDER_NAME")
+		os.Unsetenv("SMTP_SKIP_TLS")
+	}()
+
+	errChan := make(chan error, 1)
+	receivedMsgChan := make(chan string, 1)
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			errChan <- err
+			return
+		}
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		writer := bufio.NewWriter(conn)
+
+		// SMTP Greeting
+		writer.WriteString("220 localhost ESMTP Mock\r\n")
+		writer.Flush()
+
+		// Read HELO/EHLO
+		line, _ := reader.ReadString('\n')
+		if !strings.HasPrefix(line, "EHLO") && !strings.HasPrefix(line, "HELO") {
+			errChan <- nil
+			return
+		}
+		writer.WriteString("250-localhost\r\n250 AUTH PLAIN\r\n")
+		writer.Flush()
+
+		// Auth
+		line, _ = reader.ReadString('\n')
+		if strings.HasPrefix(line, "AUTH") {
+			writer.WriteString("235 2.7.0 Authentication successful\r\n")
+			writer.Flush()
+			line, _ = reader.ReadString('\n')
+		}
+
+		// Mail From
+		if !strings.HasPrefix(line, "MAIL FROM:") {
+			errChan <- nil
+			return
+		}
+		writer.WriteString("250 2.1.0 Ok\r\n")
+		writer.Flush()
+
+		// RCPT To
+		line, _ = reader.ReadString('\n')
+		if !strings.HasPrefix(line, "RCPT TO:") {
+			errChan <- nil
+			return
+		}
+		writer.WriteString("250 2.1.5 Ok\r\n")
+		writer.Flush()
+
+		// Data
+		line, _ = reader.ReadString('\n')
+		if !strings.HasPrefix(line, "DATA") {
+			errChan <- nil
+			return
+		}
+		writer.WriteString("354 Start mail input; end with <CR><LF>.<CR><LF>\r\n")
+		writer.Flush()
+
+		// Read body
+		var body strings.Builder
+		for {
+			l, _ := reader.ReadString('\n')
+			if l == ".\r\n" {
+				break
+			}
+			body.WriteString(l)
+		}
+		writer.WriteString("250 2.0.0 Ok: queued as 12345\r\n")
+		writer.Flush()
+
+		receivedMsgChan <- body.String()
+		errChan <- nil
+	}()
+
+	params := email.InvitationParams{
+		AppName:               "TestApp",
+		InvitedToName:         "John Doe",
+		InvitedToEmail:        "john@example.com",
+		InvitedByName:         "Alice",
+		URL:                   "http://localhost:8080/invite",
+		InstallCommandLinux:   "curl install",
+		InstallCommandWindows: "iwr install",
+	}
+
+	err = email.SendInvitationEmail(params)
+	if err != nil {
+		t.Fatalf("failed to send SMTP email: %v", err)
+	}
+
+	serverErr := <-errChan
+	if serverErr != nil {
+		t.Fatalf("mock SMTP server error: %v", serverErr)
+	}
+
+	receivedMsg := <-receivedMsgChan
+	if !strings.Contains(receivedMsg, "john@example.com") {
+		t.Errorf("expected email to contain recipient address, got: %s", receivedMsg)
+	}
+	if !strings.Contains(receivedMsg, "TestApp") {
+		t.Errorf("expected email to contain AppName, got: %s", receivedMsg)
+	}
+	if !strings.Contains(receivedMsg, "curl install") {
+		t.Errorf("expected email to contain Linux command, got: %s", receivedMsg)
+	}
+}

--- a/tests/smtp_test.go
+++ b/tests/smtp_test.go
@@ -2,8 +2,9 @@ package livereview
 
 import (
 	"bufio"
+	"fmt"
 	"net"
-	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -23,26 +24,7 @@ func TestSendInvitationEmailSMTP(t *testing.T) {
 		t.Fatalf("failed to get port: %v", err)
 	}
 
-	// Set env vars
-	os.Setenv("LIVEREVIEW_IS_CLOUD", "false")
-	os.Setenv("SMTP_HOST", "127.0.0.1")
-	os.Setenv("SMTP_PORT", portStr)
-	os.Setenv("SMTP_USERNAME", "testuser")
-	os.Setenv("SMTP_PASSWORD", "testpass")
-	os.Setenv("SMTP_SENDER", "sender@example.com")
-	os.Setenv("SMTP_SENDER_NAME", "Test Sender")
-	os.Setenv("SMTP_SKIP_TLS", "true") // bypass TLS validation in test
 
-	defer func() {
-		os.Unsetenv("LIVEREVIEW_IS_CLOUD")
-		os.Unsetenv("SMTP_HOST")
-		os.Unsetenv("SMTP_PORT")
-		os.Unsetenv("SMTP_USERNAME")
-		os.Unsetenv("SMTP_PASSWORD")
-		os.Unsetenv("SMTP_SENDER")
-		os.Unsetenv("SMTP_SENDER_NAME")
-		os.Unsetenv("SMTP_SKIP_TLS")
-	}()
 
 	errChan := make(chan error, 1)
 	receivedMsgChan := make(chan string, 1)
@@ -65,7 +47,7 @@ func TestSendInvitationEmailSMTP(t *testing.T) {
 		// Read HELO/EHLO
 		line, _ := reader.ReadString('\n')
 		if !strings.HasPrefix(line, "EHLO") && !strings.HasPrefix(line, "HELO") {
-			errChan <- nil
+			errChan <- fmt.Errorf("expected EHLO/HELO, got: %s", line)
 			return
 		}
 		writer.WriteString("250-localhost\r\n250 AUTH PLAIN\r\n")
@@ -81,7 +63,7 @@ func TestSendInvitationEmailSMTP(t *testing.T) {
 
 		// Mail From
 		if !strings.HasPrefix(line, "MAIL FROM:") {
-			errChan <- nil
+			errChan <- fmt.Errorf("expected MAIL FROM, got: %s", line)
 			return
 		}
 		writer.WriteString("250 2.1.0 Ok\r\n")
@@ -90,7 +72,7 @@ func TestSendInvitationEmailSMTP(t *testing.T) {
 		// RCPT To
 		line, _ = reader.ReadString('\n')
 		if !strings.HasPrefix(line, "RCPT TO:") {
-			errChan <- nil
+			errChan <- fmt.Errorf("expected RCPT TO, got: %s", line)
 			return
 		}
 		writer.WriteString("250 2.1.5 Ok\r\n")
@@ -99,7 +81,7 @@ func TestSendInvitationEmailSMTP(t *testing.T) {
 		// Data
 		line, _ = reader.ReadString('\n')
 		if !strings.HasPrefix(line, "DATA") {
-			errChan <- nil
+			errChan <- fmt.Errorf("expected DATA, got: %s", line)
 			return
 		}
 		writer.WriteString("354 Start mail input; end with <CR><LF>.<CR><LF>\r\n")
@@ -131,7 +113,17 @@ func TestSendInvitationEmailSMTP(t *testing.T) {
 		InstallCommandWindows: "iwr install",
 	}
 
-	err = email.SendInvitationEmail(params)
+	port, _ := strconv.Atoi(portStr)
+	err = email.SendInvitationEmailSMTP(
+		"127.0.0.1",
+		port,
+		"testuser",
+		"testpass",
+		"sender@example.com",
+		"Test Sender",
+		true,
+		params,
+	)
 	if err != nil {
 		t.Fatalf("failed to send SMTP email: %v", err)
 	}

--- a/ui/src/pages/Settings/SMTPSettingsTab.tsx
+++ b/ui/src/pages/Settings/SMTPSettingsTab.tsx
@@ -34,7 +34,7 @@ const SMTPSettingsTab: React.FC = () => {
     const fetchSettings = async () => {
         try {
             const data = await apiClient.get<SMTPSettings>('/api/v1/admin/settings/smtp');
-            if (data && data.host) {
+            if (data) {
                 setSettings(data);
             }
         } catch (error) {
@@ -49,7 +49,13 @@ const SMTPSettingsTab: React.FC = () => {
         setSettings(prev => ({ ...prev, [field]: value }));
     };
 
+    const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
     const handleSave = async () => {
+        if (!settings.sender || !isValidEmail(settings.sender)) {
+            toast.error('Please enter a valid Sender Email address');
+            return;
+        }
         setIsSaving(true);
         try {
             await apiClient.put('/api/v1/admin/settings/smtp', settings);
@@ -62,10 +68,14 @@ const SMTPSettingsTab: React.FC = () => {
     };
 
     const handleTest = async () => {
+        if (!settings.sender || !isValidEmail(settings.sender)) {
+            toast.error('Please enter a valid Sender Email address');
+            return;
+        }
         setIsTesting(true);
         try {
-            await apiClient.post('/api/v1/admin/settings/smtp/test', settings);
-            toast.success('Test email sent successfully! Please check your inbox.');
+            const response = await apiClient.post<{message: string}>('/api/v1/admin/settings/smtp/test', settings);
+            toast.success(response?.message || 'Test email sent successfully! Please check your inbox.');
         } catch (error: any) {
             toast.error(error?.message || 'Failed to send test email');
         } finally {
@@ -91,7 +101,7 @@ const SMTPSettingsTab: React.FC = () => {
                 </div>
                 <div>
                     <h3 className="font-medium text-white">SMTP Configuration</h3>
-                    <p className="text-sm text-slate-300">Configure global email delivery settings for user invitations</p>
+                    <p className="text-sm text-slate-300">Configure global email delivery settings</p>
                 </div>
             </div>
 
@@ -161,7 +171,7 @@ const SMTPSettingsTab: React.FC = () => {
                         variant="outline"
                         onClick={handleTest}
                         isLoading={isTesting}
-                        disabled={isSaving || isTesting || !settings.host}
+                        disabled={isSaving || isTesting || !settings.host || !settings.sender}
                     >
                         Test Connection
                     </Button>
@@ -169,7 +179,7 @@ const SMTPSettingsTab: React.FC = () => {
                         variant="primary"
                         onClick={handleSave}
                         isLoading={isSaving}
-                        disabled={isSaving || isTesting || !settings.host}
+                        disabled={isSaving || isTesting || !settings.host || !settings.sender}
                     >
                         Save Settings
                     </Button>

--- a/ui/src/pages/Settings/SMTPSettingsTab.tsx
+++ b/ui/src/pages/Settings/SMTPSettingsTab.tsx
@@ -34,7 +34,7 @@ const SMTPSettingsTab: React.FC = () => {
     const fetchSettings = async () => {
         try {
             const data = await apiClient.get<SMTPSettings>('/api/v1/admin/settings/smtp');
-            if (data) {
+            if (data && Object.keys(data).length > 0) {
                 setSettings(data);
             }
         } catch (error) {

--- a/ui/src/pages/Settings/SMTPSettingsTab.tsx
+++ b/ui/src/pages/Settings/SMTPSettingsTab.tsx
@@ -1,0 +1,182 @@
+import React, { useState, useEffect } from 'react';
+import { Button, Input, Icons } from '../../components/UIPrimitives';
+import apiClient from '../../api/apiClient';
+import toast from 'react-hot-toast';
+
+interface SMTPSettings {
+    host: string;
+    port: number;
+    username: string;
+    password: string;
+    sender: string;
+    sender_name: string;
+    skip_tls: boolean;
+}
+
+const SMTPSettingsTab: React.FC = () => {
+    const [settings, setSettings] = useState<SMTPSettings>({
+        host: '',
+        port: 587,
+        username: '',
+        password: '',
+        sender: '',
+        sender_name: 'LiveReview',
+        skip_tls: false,
+    });
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSaving, setIsSaving] = useState(false);
+    const [isTesting, setIsTesting] = useState(false);
+
+    useEffect(() => {
+        fetchSettings();
+    }, []);
+
+    const fetchSettings = async () => {
+        try {
+            const data = await apiClient.get<SMTPSettings>('/api/v1/admin/settings/smtp');
+            if (data && data.host) {
+                setSettings(data);
+            }
+        } catch (error) {
+            console.error('Failed to fetch SMTP settings:', error);
+            toast.error('Failed to load SMTP settings');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleChange = (field: keyof SMTPSettings, value: any) => {
+        setSettings(prev => ({ ...prev, [field]: value }));
+    };
+
+    const handleSave = async () => {
+        setIsSaving(true);
+        try {
+            await apiClient.put('/api/v1/admin/settings/smtp', settings);
+            toast.success('SMTP settings saved successfully!');
+        } catch (error: any) {
+            toast.error(error?.message || 'Failed to save SMTP settings');
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const handleTest = async () => {
+        setIsTesting(true);
+        try {
+            await apiClient.post('/api/v1/admin/settings/smtp/test', settings);
+            toast.success('Test email sent successfully! Please check your inbox.');
+        } catch (error: any) {
+            toast.error(error?.message || 'Failed to send test email');
+        } finally {
+            setIsTesting(false);
+        }
+    };
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center p-8">
+                <div className="w-8 h-8 border-2 border-indigo-500 border-t-transparent rounded-full animate-spin"></div>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <div className="flex items-center mb-6">
+                <div className="text-indigo-400 mr-3">
+                    <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                    </svg>
+                </div>
+                <div>
+                    <h3 className="font-medium text-white">SMTP Configuration</h3>
+                    <p className="text-sm text-slate-300">Configure global email delivery settings for user invitations</p>
+                </div>
+            </div>
+
+            <div className="space-y-6">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <Input
+                        label="SMTP Host"
+                        placeholder="smtp.example.com"
+                        value={settings.host}
+                        onChange={(e) => handleChange('host', e.target.value)}
+                    />
+                    <Input
+                        label="SMTP Port"
+                        type="number"
+                        placeholder="587"
+                        value={settings.port.toString()}
+                        onChange={(e) => handleChange('port', parseInt(e.target.value) || 587)}
+                    />
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <Input
+                        label="Username"
+                        placeholder="user@example.com"
+                        value={settings.username}
+                        onChange={(e) => handleChange('username', e.target.value)}
+                    />
+                    <Input
+                        label="Password"
+                        type="password"
+                        placeholder="••••••••"
+                        value={settings.password}
+                        onChange={(e) => handleChange('password', e.target.value)}
+                    />
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <Input
+                        label="Sender Email (From)"
+                        placeholder="noreply@example.com"
+                        value={settings.sender}
+                        onChange={(e) => handleChange('sender', e.target.value)}
+                    />
+                    <Input
+                        label="Sender Name"
+                        placeholder="LiveReview"
+                        value={settings.sender_name}
+                        onChange={(e) => handleChange('sender_name', e.target.value)}
+                    />
+                </div>
+
+                <div className="flex items-center space-x-2 bg-slate-800 p-4 rounded-lg">
+                    <input
+                        type="checkbox"
+                        id="skipTls"
+                        checked={settings.skip_tls}
+                        onChange={(e) => handleChange('skip_tls', e.target.checked)}
+                        className="w-4 h-4 text-indigo-600 bg-slate-700 border-slate-600 rounded focus:ring-indigo-500 focus:ring-2"
+                    />
+                    <label htmlFor="skipTls" className="text-sm font-medium text-slate-300">
+                        Skip TLS Verification (Insecure, useful for self-signed certs)
+                    </label>
+                </div>
+
+                <div className="flex justify-end space-x-3 pt-4 border-t border-slate-700">
+                    <Button
+                        variant="outline"
+                        onClick={handleTest}
+                        isLoading={isTesting}
+                        disabled={isSaving || isTesting || !settings.host}
+                    >
+                        Test Connection
+                    </Button>
+                    <Button
+                        variant="primary"
+                        onClick={handleSave}
+                        isLoading={isSaving}
+                        disabled={isSaving || isTesting || !settings.host}
+                    >
+                        Save Settings
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default SMTPSettingsTab;

--- a/ui/src/pages/Settings/Settings.tsx
+++ b/ui/src/pages/Settings/Settings.tsx
@@ -6,6 +6,7 @@ import LicenseTab from './LicenseTab';
 import SubscriptionTab from './SubscriptionTab';
 import LearningsTab from './LearningsTab';
 import APIKeysTab from './APIKeysTab';
+import SMTPSettingsTab from './SMTPSettingsTab';
 import { UserManagement } from '../../components/UserManagement';
 import LicenseManagement from '../Licenses/LicenseManagement';
 import { useOrgContext } from '../../hooks/useOrgContext';
@@ -283,6 +284,15 @@ const Settings = () => {
     // Available tabs based on permissions
     const tabs = [
         ...(isSuperAdmin ? [{ id: 'instance', name: 'Instance', icon: <Icons.Settings /> }] : []),
+        ...(isSuperAdmin ? [{ 
+            id: 'smtp', 
+            name: 'SMTP', 
+            icon: (
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+            )
+        }] : []),
         ...(isSuperAdmin ? [{ 
             id: 'deployment', 
             name: 'Deployment', 
@@ -690,6 +700,12 @@ const Settings = () => {
                                     </div>
                                 </div>
                             </div>
+                        </Card>
+                    )}
+
+                    {activeTab === 'smtp' && isSuperAdmin && (
+                        <Card>
+                            <SMTPSettingsTab />
                         </Card>
                     )}
 

--- a/ui/src/pages/Settings/Settings.tsx
+++ b/ui/src/pages/Settings/Settings.tsx
@@ -284,7 +284,7 @@ const Settings = () => {
     // Available tabs based on permissions
     const tabs = [
         ...(isSuperAdmin ? [{ id: 'instance', name: 'Instance', icon: <Icons.Settings /> }] : []),
-        ...(isSuperAdmin ? [{ 
+        ...(isSuperAdmin && !isCloudMode() ? [{ 
             id: 'smtp', 
             name: 'SMTP', 
             icon: (
@@ -703,7 +703,7 @@ const Settings = () => {
                         </Card>
                     )}
 
-                    {activeTab === 'smtp' && isSuperAdmin && (
+                    {activeTab === 'smtp' && isSuperAdmin && !isCloudMode() && (
                         <Card>
                             <SMTPSettingsTab />
                         </Card>


### PR DESCRIPTION
- Added global SMTP configuration settings specifically for self-hosted instances.
- Restricted access so the settings are only visible to Super Admins and hidden in cloud mode.
- Created a new Admin UI tab for adding, editing, and managing SMTP connection details.
- Implemented database migrations and backend handlers to securely store the configuration.
- Added a "Test Connection" feature to instantly verify the SMTP credentials via a custom test email.
- Updated email templates to dynamically support white-labeling (dynamic app names and copyright years).

## Screenshots
<img width="1599" height="774" alt="image" src="https://github.com/user-attachments/assets/a74b7aae-1089-4bfb-a1ee-c1468a25ad75" />

<img width="717" height="495" alt="image" src="https://github.com/user-attachments/assets/5f77d3cc-225a-4f9f-b20f-ea5488f48242" />
