### PR TITLE
Update Gemini Model leader and helper default

### DIFF
--- a/db/migrations/20260905000000_update_default_gemini_flash_model.sql
+++ b/db/migrations/20260905000000_update_default_gemini_flash_model.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+-- Bump the system-managed "default" tier from Gemini 2.5 Flash to 3.6 Flash.
+UPDATE system_default_ai_configs
+SET model_name = 'gemini-3.6-flash', updated_at = CURRENT_TIMESTAMP
+WHERE tier_name = 'default' AND provider_name = 'gemini' AND model_name = 'gemini-2.5-flash';
+
+-- migrate:down
+UPDATE system_default_ai_configs
+SET model_name = 'gemini-2.5-flash', updated_at = CURRENT_TIMESTAMP
+WHERE tier_name = 'default' AND provider_name = 'gemini' AND model_name = 'gemini-3.6-flash';

--- a/db/migrations/20260905010000_update_gemini_flash_pricing.sql
+++ b/db/migrations/20260905010000_update_gemini_flash_pricing.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+-- Gemini 3.6 Flash replaces 2.5 Flash as the default model
+-- (20260905000000_update_default_gemini_flash_model.sql). Its promotional rate
+-- ($0.75 / $3.75 per M input/output tokens, valid through 2026-12-31) differs
+-- from 2.5 Flash's ($0.30 / $2.50), so the shared "gemini"/"googleai"
+-- provider_key rows must move too or every plan keeps billing at the old rate.
+-- Flash-Lite rows (provider_key gemini_flash_lite/googleai_flash_lite, added in
+-- 20260702130000_fix_gemini_flash_lite_pricing.sql) are untouched.
+UPDATE quota_policy_catalog
+SET input_cost_per_million_tokens_usd = 0.75,
+    output_cost_per_million_tokens_usd = 3.75,
+    updated_at = CURRENT_TIMESTAMP
+WHERE provider_key IN ('gemini', 'googleai');
+
+-- migrate:down
+UPDATE quota_policy_catalog
+SET input_cost_per_million_tokens_usd = 0.3,
+    output_cost_per_million_tokens_usd = 2.5,
+    updated_at = CURRENT_TIMESTAMP
+WHERE provider_key IN ('gemini', 'googleai');

--- a/db/migrations/20260905020000_update_default_gemini_flash_lite_model.sql
+++ b/db/migrations/20260905020000_update_default_gemini_flash_lite_model.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+-- Bump the system-managed "default_lite" tier from Gemini 2.5 Flash-Lite to 3.5 Flash-Lite.
+UPDATE system_default_ai_configs
+SET model_name = 'gemini-3.5-flash-lite', updated_at = CURRENT_TIMESTAMP
+WHERE tier_name = 'default_lite' AND provider_name = 'gemini' AND model_name = 'gemini-2.5-flash-lite';
+
+-- migrate:down
+UPDATE system_default_ai_configs
+SET model_name = 'gemini-2.5-flash-lite', updated_at = CURRENT_TIMESTAMP
+WHERE tier_name = 'default_lite' AND provider_name = 'gemini' AND model_name = 'gemini-3.5-flash-lite';

--- a/db/migrations/20260905030000_update_gemini_flash_lite_pricing.sql
+++ b/db/migrations/20260905030000_update_gemini_flash_lite_pricing.sql
@@ -1,0 +1,19 @@
+-- migrate:up
+-- Gemini 3.5 Flash-Lite replaces 2.5 Flash-Lite as the helper model
+-- (20260905020000_update_default_gemini_flash_lite_model.sql). Its paid rate
+-- ($0.30 / $2.50 per M input/output tokens) differs from 2.5 Flash-Lite's
+-- ($0.10 / $0.40), so the dedicated gemini_flash_lite/googleai_flash_lite
+-- provider_key rows (added in 20260702130000_fix_gemini_flash_lite_pricing.sql)
+-- must move too.
+UPDATE quota_policy_catalog
+SET input_cost_per_million_tokens_usd = 0.30,
+    output_cost_per_million_tokens_usd = 2.50,
+    updated_at = CURRENT_TIMESTAMP
+WHERE provider_key IN ('gemini_flash_lite', 'googleai_flash_lite');
+
+-- migrate:down
+UPDATE quota_policy_catalog
+SET input_cost_per_million_tokens_usd = 0.10,
+    output_cost_per_million_tokens_usd = 0.40,
+    updated_at = CURRENT_TIMESTAMP
+WHERE provider_key IN ('gemini_flash_lite', 'googleai_flash_lite');

--- a/internal/ai/gemini/gemini.go
+++ b/internal/ai/gemini/gemini.go
@@ -20,6 +20,9 @@ import (
 	"github.com/tmc/langchaingo/llms"
 )
 
+// DefaultModel is the Gemini model used when no model is configured.
+const DefaultModel = "gemini-3.6-flash"
+
 type GeminiProvider struct {
 	TestableFields
 	llm llms.Model
@@ -52,7 +55,7 @@ func New(config GeminiConfig) (*GeminiProvider, error) {
 	}
 
 	if config.Model == "" {
-		config.Model = "gemini-2.5-flash"
+		config.Model = DefaultModel
 	}
 
 	if config.Temperature == 0 {

--- a/internal/aiconnectors/models_sync.go
+++ b/internal/aiconnectors/models_sync.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/livereview/internal/ai/gemini"
 	"github.com/rs/zerolog/log"
 )
 
@@ -62,7 +63,7 @@ type MappedModel struct {
 var defaultProviderModels = map[string]string{
 	"openai":     "gpt-5.5",
 	"claude":     "claude-sonnet-4.6",
-	"gemini":     "gemini-2.5-flash",
+	"gemini":     gemini.DefaultModel,
 	"deepseek":   "deepseek-v4-flash",
 	"cohere":     "command-a",
 	"openrouter": "deepseek/deepseek-v4-flash",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
+	"github.com/livereview/internal/ai/gemini"
 )
 
 // Config represents the application configuration
@@ -74,7 +75,7 @@ func InitConfig(configPath string) error {
 	}
 
 	// Create sample configuration
-	sampleConfig := `# LiveReview Configuration
+	sampleConfig := fmt.Sprintf(`# LiveReview Configuration
 
 [general]
 default_provider = "gitlab"
@@ -86,9 +87,9 @@ token = "your-gitlab-token"
 
 [ai.gemini]
 api_key = "your-gemini-api-key"
-model = "gemini-2.5-flash"
+model = "%s"
 temperature = 0.2
-`
+`, gemini.DefaultModel)
 
 	return os.WriteFile(configPath, []byte(sampleConfig), 0644)
 }

--- a/internal/review/config.go
+++ b/internal/review/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/livereview/internal/ai/gemini"
 	"github.com/livereview/internal/config"
 )
 
@@ -69,7 +70,7 @@ func (cs *ConfigurationService) buildAIConfig() (AIConfig, error) {
 
 	// Set defaults if not specified
 	if model == "" {
-		model = "gemini-2.5-flash"
+		model = gemini.DefaultModel
 	}
 	if temperature == 0 {
 		temperature = 0.4
@@ -89,7 +90,7 @@ func DefaultReviewConfig() Config {
 	return Config{
 		ReviewTimeout: 10 * time.Minute,
 		DefaultAI:     "langchain",
-		DefaultModel:  "gemini-2.5-flash",
+		DefaultModel:  gemini.DefaultModel,
 		Temperature:   0.4,
 	}
 }

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -595,11 +595,13 @@ func calculateBillableLOCFromDiffs(diffs []*models.CodeDiff) int64 {
 // 20260622180000_seed_enterprise_quota_policy.sql). Stage-level cost estimates use
 // these so the "Model Breakdown" panel is priced consistently with the deterministic
 // ledger total shown in the Accounting panel, instead of one flat rate for every provider.
+// gemini/googleai rate is Gemini 3.6 Flash's promotional rate, valid through
+// 2026-12-31 (db/migrations/20260905010000_update_gemini_flash_pricing.sql) — revisit after.
 var perMillionTokenRates = map[string][2]float64{
 	"default":    {5.0, 15.0},
 	"openai":     {5.0, 15.0},
-	"gemini":     {0.3, 2.5},
-	"googleai":   {0.3, 2.5},
+	"gemini":     {0.75, 3.75},
+	"googleai":   {0.75, 3.75},
 	"claude":     {15.0, 75.0},
 	"anthropic":  {15.0, 75.0},
 	"deepseek":   {1.0, 2.0},
@@ -609,12 +611,12 @@ var perMillionTokenRates = map[string][2]float64{
 	"atlas":      {1.0, 2.0},
 }
 
-// flashLiteRate is Gemini 2.5 Flash-Lite's own per-million-token rate
-// (db/migrations/20260702130000_fix_gemini_flash_lite_pricing.sql). The base
+// flashLiteRate is Gemini 3.5 Flash-Lite's own per-million-token rate
+// (db/migrations/20260905030000_update_gemini_flash_lite_pricing.sql). The base
 // "gemini"/"googleai" rows in perMillionTokenRates price Flash, not
-// Flash-Lite (roughly 3-6x more expensive per token than Flash-Lite), so a
-// Gemini/GoogleAI call also needs its model name checked to catch Flash-Lite.
-var flashLiteRate = [2]float64{0.10, 0.40}
+// Flash-Lite, so a Gemini/GoogleAI call also needs its model name checked to
+// catch Flash-Lite.
+var flashLiteRate = [2]float64{0.30, 2.50}
 
 func ratesPerTokenForProvider(provider, model string) (inputRate, outputRate float64) {
 	key := strings.ToLower(strings.TrimSpace(provider))

--- a/scripts/examples/review_demo.go
+++ b/scripts/examples/review_demo.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/livereview/internal/ai/gemini"
 	"github.com/livereview/internal/config"
 	"github.com/livereview/internal/review"
 )
@@ -32,7 +33,7 @@ func main() {
 	reviewConfig := review.Config{
 		ReviewTimeout: 10 * time.Minute,
 		DefaultAI:     "gemini",
-		DefaultModel:  "gemini-2.5-flash",
+		DefaultModel:  gemini.DefaultModel,
 		Temperature:   0.4,
 	}
 


### PR DESCRIPTION
LiveReview Pre-Commit Check: ran (iter:1, coverage:0%)

## Summary

- Centralize the hardcoded Gemini model strings into gemini.DefaultModel, then bump defaults: leader gemini-2.5-flash → gemini-3.6-flash, helper gemini-2.5-flash-lite → gemini-3.5-flash-lite.
- Update pricing to match: Flash → $0.75/$3.75 per M tokens (promo through 2026-12-31), Flash-Lite → $0.30/$2.50 per M tokens.

## Linked Issue

Link the agreed issue this PR fulfills.

## Validation

Describe the most specific test or validation you ran.

## Checklist

- [x] This PR fulfills an agreed issue.
- [x] I kept the change narrow and scoped.
- [x] I ran the most specific relevant validation and described it above.
- [ ] If I changed behavior, I called that out clearly in this PR.
- [ ] If I touched UI, I attached a GIF or video walkthrough. This is required.
- [ ] If this change touches security, disclosure flow, credentials, storage, network behavior, or licensing/entitlement enforcement, I reviewed `SECURITY.md` and updated related documentation if needed.
- [x] I have read and accept the [Contributor License Agreement](../CLA.md).

## Notes For Reviewers

Anything specific you want reviewers to focus on.
